### PR TITLE
add return value to normalize!

### DIFF
--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -128,7 +128,7 @@ function ptrace(psi::Bra, indices::Vector{Int})
     return DenseOperator(b_, b_, result)
 end
 
-normalize!(op::DenseOperator) = (rmul!(op.data, 1.0/tr(op)); nothing)
+normalize!(op::DenseOperator) = (rmul!(op.data, 1.0/tr(op)); op)
 
 function expect(op::DenseOperator{B,B}, state::Ket{B}) where B<:Basis
     state.data' * op.data * state.data

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -64,7 +64,7 @@ function ptrace(op::LazySum, indices::Vector{Int})
     LazySum(op.factors, D)
 end
 
-normalize!(op::LazySum) = (op.factors /= tr(op); nothing)
+normalize!(op::LazySum) = (op.factors /= tr(op); op)
 
 permutesystems(op::LazySum, perm::Vector{Int}) = LazySum(op.factors, ([permutesystems(op_i, perm) for op_i in op.operators]...,))
 

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -159,7 +159,7 @@ function ptrace(op::LazyTensor, indices::Vector{Int})
     LazyTensor(b_l, b_r, shiftremove(op.indices, indices), ops, factor)
 end
 
-normalize!(op::LazyTensor) = (op.factor /= tr(op); nothing)
+normalize!(op::LazyTensor) = (op.factor /= tr(op); op)
 
 function permutesystems(op::LazyTensor, perm::Vector{Int})
     b_l = permutesystems(op.basis_l, perm)

--- a/src/states.jl
+++ b/src/states.jl
@@ -126,7 +126,7 @@ normalize(x::StateVector) = x/norm(x)
 
 In-place normalization of the given bra or ket so that `norm(x)` is one.
 """
-normalize!(x::StateVector) = (rmul!(x.data, 1.0/norm(x)); nothing)
+normalize!(x::StateVector) = (rmul!(x.data, 1.0/norm(x)); x)
 
 function permutesystems(state::T, perm::Vector{Int}) where T<:Ket
     @assert length(state.basis.bases) == length(perm)

--- a/test/test_operators_dense.jl
+++ b/test/test_operators_dense.jl
@@ -171,6 +171,7 @@ op_copy = deepcopy(op)
 normalize!(op_copy)
 @test tr(op) != tr(op_copy)
 @test 1 ≈ tr(op_copy)
+@test op === normalize!(op)
 
 # Test partial tr of state vectors
 psi1 = 0.1*randstate(b1a)

--- a/test/test_operators_lazysum.jl
+++ b/test/test_operators_lazysum.jl
@@ -111,6 +111,8 @@ op_copy = deepcopy(op)
 normalize!(op_copy)
 @test tr(op) != tr(op_copy)
 @test 1 ≈ tr(op_copy)
+@test op_copy === normalize!(op_copy)
+
 
 # Test partial tr
 op1 = randoperator(b_l)


### PR DESCRIPTION
```Julia
using LinearAlgebra
julia> normalize!(rand(5))
5-element Array{Float64,1}:
 0.6110615634304324 
 0.5571396063270291 
 0.5393678465871397 
 0.1017128598624379 
 0.12221311290640892
```

but not in QuantumOptics...