### PR TITLE
Renyi entropy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "v0.1.2"
+version = "v0.1.3"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -27,7 +27,7 @@ export bases, Basis, GenericBasis, CompositeBasis, basis,
                 manybodyoperator, onebodyexpect, occupation,
         metrics, tracenorm, tracenorm_h, tracenorm_nh,
                 tracedistance, tracedistance_h, tracedistance_nh,
-                entropy_vn, fidelity, ptranspose, PPT,
+                entropy_vn, entropy_renyi, fidelity, ptranspose, PPT,
                 negativity, logarithmic_negativity, entanglement_entropy,
         PauliBasis, PauliTransferMatrix, DensePauliTransferMatrix,
                 ChiMatrix, DenseChiMatrix, avg_gate_fidelity

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -149,6 +149,26 @@ end
 entropy_vn(psi::StateVector; kwargs...) = entropy_vn(dm(psi); kwargs...)
 
 """
+    entropy_renyi(rho, α::Integer=2)
+
+Renyi α-entropy of a density matrix, where r α≥0, α≂̸1.
+
+The Renyi α-entropy of a density operator is defined as
+
+```math
+S_α(ρ) = 1/(1-α) \\log(Tr(ρ^α))
+```
+"""
+function entropy_renyi(rho::DenseOperator{B,B}, α::Integer=2) where B<:Basis
+    α <  0 && throw(ArgumentError("α-Renyi entropy is defined for α≥0, α≂̸1"))
+    α == 1 && throw(ArgumentError("α-Renyi entropy is defined for α≥0, α≂̸1"))
+
+    return 1/(1-α) * log(tr(rho^α))
+end
+
+entropy_renyi(psi::StateVector, args...) = entropy_renyi(dm(psi), args...)
+
+"""
     fidelity(rho, sigma)
 
 Fidelity of two density operators.

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -54,11 +54,18 @@ rho = spinup(b1) ⊗ dagger(coherentstate(b2, 0.1))
 
 @test tracedistance_nh(rho, rho) ≈ 0.
 
-# entropy
+# entropy_vn
 rho_mix = dense(identityoperator(b1))/2.
 @test entropy_vn(rho_mix)/log(2) ≈ 1
 psi = coherentstate(FockBasis(20), 2.0)
 @test isapprox(entropy_vn(psi), 0.0, atol=1e-8)
+
+# entropy_renyi
+rho_mix = dense(identityoperator(b1))/2.
+@test entropy_renyi(rho_mix, 2)/log(2) ≈ 1
+psi = coherentstate(FockBasis(20), 2.0)
+@test isapprox(entropy_renyi(psi), 0.0, atol=1e-8)
+@test_throws ArgumentError entropy_renyi(psi, 1)
 
 # fidelity
 rho = tensor(psi1, dagger(psi1))


### PR DESCRIPTION
only for integer \alpha.
For non-integer we should add the exponential of non-integer operators, which is easy, but the algorithm in base is extremely unstable for low rank so I'd rather think a bit more about it.