### PR TITLE
Implement offset in FockBasis

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -50,7 +50,11 @@ function show(stream::IO, x::SpinBasis)
 end
 
 function show(stream::IO, x::FockBasis)
-    write(stream, "Fock(cutoff=$(x.N))")
+    if iszero(x.offset)
+        write(stream, "Fock(cutoff=$(x.N))")
+    else
+        write(stream, "Fock(cutoff=$(x.N), offset=$(x.offset))")
+    end
 end
 
 function show(stream::IO, x::NLevelBasis)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -16,7 +16,6 @@ a harmonic trap potential at position ``x``, i.e.:
 ```
 """
 function transform(b1::PositionBasis, b2::FockBasis; x0::Real=1)
-    @assert b2.offset==0 # TODO
     T = Matrix{ComplexF64}(undef, length(b1), length(b2))
     xvec = samplepoints(b1)
     A = hermite.A(b2.N)
@@ -25,15 +24,15 @@ function transform(b1::PositionBasis, b2::FockBasis; x0::Real=1)
     for i in 1:length(b1)
         u = xvec[i]/x0
         C = c*exp(-u^2/2)
-        for n=0:b2.N
-            T[i,n+1] = C*horner(A[n+1], u)
+        for n=b2.offset:b2.N
+            idx = n-b2.offset+1
+            T[i,idx] = C*horner(A[n+1], u)
         end
     end
     DenseOperator(b1, b2, T)
 end
 
 function transform(b1::FockBasis, b2::PositionBasis; x0::Real=1)
-    @assert b1.offset==0 # TODO
     T = Matrix{ComplexF64}(undef, length(b1), length(b2))
     xvec = samplepoints(b2)
     A = hermite.A(b1.N)
@@ -42,8 +41,9 @@ function transform(b1::FockBasis, b2::PositionBasis; x0::Real=1)
     for i in 1:length(b2)
         u = xvec[i]/x0
         C = c*exp(-u^2/2)
-        for n=0:b1.N
-            T[n+1,i] = C*horner(A[n+1], u)
+        for n=b1.offset:b1.N
+            idx = n-b1.offset+1
+            T[idx,i] = C*horner(A[n+1], u)
         end
     end
     DenseOperator(b1, b2, T)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -16,6 +16,7 @@ a harmonic trap potential at position ``x``, i.e.:
 ```
 """
 function transform(b1::PositionBasis, b2::FockBasis; x0::Real=1)
+    @assert b2.offset==0 # TODO
     T = Matrix{ComplexF64}(undef, length(b1), length(b2))
     xvec = samplepoints(b1)
     A = hermite.A(b2.N)
@@ -32,6 +33,7 @@ function transform(b1::PositionBasis, b2::FockBasis; x0::Real=1)
 end
 
 function transform(b1::FockBasis, b2::PositionBasis; x0::Real=1)
+    @assert b1.offset==0 # TODO
     T = Matrix{ComplexF64}(undef, length(b1), length(b2))
     xvec = samplepoints(b2)
     A = hermite.A(b1.N)

--- a/test/test_fock.jl
+++ b/test/test_fock.jl
@@ -69,4 +69,17 @@ rho = dm(psi)
 @test 1e-13 > abs(variance(n, psi) - abs(alpha)^2)
 @test 1e-13 > abs(variance(n, rho) - abs(alpha)^2)
 
+# Test FockBasis with offset
+b_off = FockBasis(100,4)
+@test_throws AssertionError fockstate(b_off, 0)
+n = 55
+psi = fockstate(b_off, n)
+@test expect(number(b_off), psi)==n==expect(create(b_off)*destroy(b_off), psi)
+
+alpha = 5
+psi = coherentstate(b, alpha)
+psi_off = coherentstate(b_off, alpha)
+@test psi.data[b_off.offset+1:end] == psi_off.data
+@test isapprox(norm(psi_off), 1, atol=1e-7)
+
 end # testset

--- a/test/test_transformations.jl
+++ b/test/test_transformations.jl
@@ -40,17 +40,20 @@ psi_x = gaussianstate(b_position, x0/σ0, p0/σ0, σ0)
 
 # Test with offset in FockBasis
 b_fock = FockBasis(50,1)
-b_position = PositionBasis(0, 20, 200)
+b_position = PositionBasis(-10, 10, 300)
 
-x0 = 6.0
-p0 = 2.2
+x0 = 6.1
+p0 = 0.3
 α0 = (x0 + 1im*p0)/sqrt(2)
-σ0 = 0.7
 
 psi_n = coherentstate(b_fock, α0)
-psi_x = gaussianstate(b_position, x0/σ0, p0/σ0, σ0)
+psi_x = gaussianstate(b_position, x0, p0, 1)
 @test isapprox(norm(psi_n), 1, atol=1e-8)
 
-Txn = transform(b_position, b_fock; x0=σ0)
+Txn = transform(b_position, b_fock)
+Tnx = transform(b_fock, b_position)
+@test 1e-10 > D(dagger(Txn), Tnx)
+@test 1e-4 > D(psi_x, Txn*psi_n)
+@test 1e-4 > D(psi_n, Tnx*psi_x)
 
 end # testset

--- a/test/test_transformations.jl
+++ b/test/test_transformations.jl
@@ -38,6 +38,19 @@ psi_n = coherentstate(b_fock, α0)
 psi_x = gaussianstate(b_position, x0/σ0, p0/σ0, σ0)
 @test 1e-10 > D(psi_x, Txn*psi_n)
 
+# Test with offset in FockBasis
+b_fock = FockBasis(50,1)
+b_position = PositionBasis(0, 20, 200)
 
+x0 = 6.0
+p0 = 2.2
+α0 = (x0 + 1im*p0)/sqrt(2)
+σ0 = 0.7
+
+psi_n = coherentstate(b_fock, α0)
+psi_x = gaussianstate(b_position, x0/σ0, p0/σ0, σ0)
+@test isapprox(norm(psi_n), 1, atol=1e-8)
+
+Txn = transform(b_position, b_fock; x0=σ0)
 
 end # testset


### PR DESCRIPTION
The `transform` methods for transforming back and forth between `FockBasis` and `PositionBasis` still need to be adapted for offsets.