### PR TITLE
Phase space functions declaration

### DIFF
--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -32,7 +32,8 @@ export bases, Basis, GenericBasis, CompositeBasis, basis,
                 negativity, logarithmic_negativity, entanglement_entropy,
         PauliBasis, PauliTransferMatrix, DensePauliTransferMatrix,
                 ChiMatrix, DenseChiMatrix, avg_gate_fidelity,
-        SumBasis, directsum, ⊕, LazyDirectSum, getblock, setblock!
+        SumBasis, directsum, ⊕, LazyDirectSum, getblock, setblock!,
+        qfunc, wigner, coherentspinstate, qfuncsu2, wignersu2
 
 include("sortedindices.jl")
 include("polynomials.jl")
@@ -57,6 +58,7 @@ include("transformations.jl")
 include("pauli.jl")
 include("metrics.jl")
 include("spinors.jl")
+include("phasespace.jl")
 include("printing.jl")
 
 end # module

--- a/src/phasespace.jl
+++ b/src/phasespace.jl
@@ -1,0 +1,5 @@
+function qfunc end
+function wigner end
+function coherentspinstate end
+function qfuncsu2 end
+function wignersu2 end


### PR DESCRIPTION
It would be useful for other packages to be able to extend functions of QuantumOptics without depending on QuantumOptics.jl itself. I added to QuantumOpticsBase.jl declarations of phase space functions: `qfunc`, `wigner`, `coherentspinstate`, `qfuncsu2`, `wignersu2`.
I especially needed `wigner` for a package I am developing, but also the other functions may be useful to others. I made changes also to QuantumOptics.jl to accommodate this. 
I hope this can be useful.