### PR TITLE
Fix documentation of `negativity`

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -227,7 +227,7 @@ Negativity of rho with respect to subsystem index.
 The negativity of a density matrix ρ is defined as
 
 ```math
-N(ρ) = \\|ρᵀ\\|,
+N(ρ) = \\frac{\\|ρᵀ\\|-1}{2},
 ```
 where `ρᵀ` is the partial transpose.
 """


### PR DESCRIPTION
The documentation doesn't fit the code; which implements: https://en.wikipedia.org/wiki/Negativity_(quantum_mechanics)