### PR TITLE
Added typed construtors for operators FockBasis

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -1,4 +1,4 @@
-import Base: ==, +, -, *, /, length, copy
+import Base: ==, +, -, *, /, length, copy, eltype
 import LinearAlgebra: norm, normalize, normalize!
 
 """
@@ -38,6 +38,9 @@ mutable struct Ket{B<:Basis,T<:AbstractVector} <: StateVector{B,T}
         new(b, data)
     end
 end
+
+eltype(::Type{K}) where {K <: Ket{B,V}} where {B,V} = eltype(V)
+eltype(::Type{K}) where {K <: Bra{B,V}} where {B,V} = eltype(V)
 
 Bra{B}(b::B, data::T) where {B<:Basis,T} = Bra{B,T}(b, data)
 Ket{B}(b::B, data::T) where {B<:Basis,T} = Ket{B,T}(b, data)


### PR DESCRIPTION
I initiated to apply the changes as discussed in #24. Before completing I think we should review the changes I made so far. I think there are some options also for the docs. The changes I made in `fock.jl` for the operators are what I am used to. I can modify, if you consider to be better another way.