### PR TITLE
Type-stable constructor for LazyTensor

### DIFF
--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -23,6 +23,7 @@ Operator(b::Basis,data) = Operator(b,b,data)
 
 Base.zero(op::Operator) = Operator(op.basis_l,op.basis_r,zero(op.data))
 Base.eltype(op::Operator) = eltype(op.data)
+Base.eltype(::Type{T}) where {BL,BR,D,T<:Operator{BL,BR,D}} = eltype(D)
 Base.size(op::Operator) = size(op.data)
 Base.size(op::Operator, d::Int) = size(op.data, d)
 

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -17,7 +17,7 @@ mutable struct LazyTensor{BL,BR,F,I,T} <: AbstractOperator{BL,BR}
     factor::F
     indices::I
     operators::T
-    function LazyTensor(bl::BL, br::BR, indices::I, ops::T, factor::F) where {BL<:CompositeBasis,BR<:CompositeBasis,F,I,T<:Tuple}
+    function LazyTensor(bl::BL, br::BR, indices::I, ops::T, factor::F=_default_factor(ops)) where {BL<:CompositeBasis,BR<:CompositeBasis,F,I,T<:Tuple}
         N = length(bl.bases)
         @assert N==length(br.bases)
         check_indices(N, indices)
@@ -33,7 +33,11 @@ mutable struct LazyTensor{BL,BR,F,I,T} <: AbstractOperator{BL,BR}
         new{BL,BR,F_,I,T}(bl, br, factor_, indices, ops)
     end
 end
-LazyTensor(bl::CompositeBasis, br::CompositeBasis, indices, ops, factor=_default_factor(ops)) = LazyTensor(bl, br, indices, (ops...,), factor)
+function LazyTensor(bl::CompositeBasis, br::CompositeBasis, indices, ops::Vector, factor=_default_factor(ops))
+    Base.depwarn("LazyTensor(bl, br, indices, ops::Vector, factor) is deprecated, use LazyTensor(bl, br, indices, Tuple(ops), factor) instead.",
+                :LazyTensor; force=true)
+    return LazyTensor(bl,br,indices,Tuple(ops),factor)
+end
 
 function LazyTensor(basis_l::CompositeBasis, basis_r::Basis, indices::I, ops, factor::F=_default_factor(ops)) where {F,I}
     br = CompositeBasis(basis_r.shape, [basis_r])
@@ -52,7 +56,7 @@ LazyTensor(op::T, factor) where {T<:LazyTensor} = LazyTensor(op.basis_l, op.basi
 LazyTensor(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, operator::T, factor=one(eltype(operator))) where T<:AbstractOperator = LazyTensor(basis_l, basis_r, [index], (operator,), factor)
 LazyTensor(basis::Basis, index, operators, factor=_default_factor(operators)) = LazyTensor(basis, basis, index, operators, factor)
 
-Base.copy(x::LazyTensor) = LazyTensor(x.basis_l, x.basis_r, copy(x.indices), [copy(op) for op in x.operators], x.factor)
+Base.copy(x::LazyTensor) = LazyTensor(x.basis_l, x.basis_r, copy(x.indices), Tuple(copy(op) for op in x.operators), x.factor)
 Base.eltype(x::LazyTensor) = promote_type(eltype(x.factor), eltype.(x.operators)...)
 
 function _default_factor(ops)
@@ -91,21 +95,22 @@ SparseArrays.sparse(op::LazyTensor) = op.factor*embed(op.basis_l, op.basis_r, op
 
 function *(a::LazyTensor{B1,B2}, b::LazyTensor{B2,B3}) where {B1,B2,B3}
     indices = sort(union(a.indices, b.indices))
-    ops = Vector{AbstractOperator}(undef, length(indices))
-    for n in 1:length(indices)
+    # ops = Vector{AbstractOperator}(undef, length(indices))
+    function _prod(n)
         i = indices[n]
         in_a = i in a.indices
         in_b = i in b.indices
         if in_a && in_b
-            ops[n] = suboperator(a, i)*suboperator(b, i)
+            return suboperator(a, i)*suboperator(b, i)
         elseif in_a
             a_i = suboperator(a, i)
-            ops[n] = a_i*identityoperator(typeof(a_i), b.basis_l.bases[i], b.basis_r.bases[i])
+            return a_i*identityoperator(typeof(a_i), b.basis_l.bases[i], b.basis_r.bases[i])
         elseif in_b
             b_i = suboperator(b, i)
-            ops[n] = identityoperator(typeof(b_i), a.basis_l.bases[i], a.basis_r.bases[i])*b_i
+            return identityoperator(typeof(b_i), a.basis_l.bases[i], a.basis_r.bases[i])*b_i
         end
     end
+    ops = Tuple(_prod(n) for n ∈ 1:length(indices))
     return LazyTensor(a.basis_l, b.basis_r, indices, ops, a.factor*b.factor)
 end
 *(a::LazyTensor, b::Number) = LazyTensor(a, a.factor*b)
@@ -124,9 +129,9 @@ end
 /(a::LazyTensor, b::Number) = LazyTensor(a, a.factor/b)
 
 
-dagger(op::LazyTensor) = LazyTensor(op.basis_r, op.basis_l, op.indices, AbstractOperator[dagger(x) for x in op.operators], conj(op.factor))
+dagger(op::LazyTensor) = LazyTensor(op.basis_r, op.basis_l, op.indices, Tuple(dagger(x) for x in op.operators), conj(op.factor))
 
-tensor(a::LazyTensor, b::LazyTensor) = LazyTensor(a.basis_l ⊗ b.basis_l, a.basis_r ⊗ b.basis_r, [a.indices; b.indices .+ length(a.basis_l.bases)], [a.operators..., b.operators...], a.factor*b.factor)
+tensor(a::LazyTensor, b::LazyTensor) = LazyTensor(a.basis_l ⊗ b.basis_l, a.basis_r ⊗ b.basis_r, [a.indices; b.indices .+ length(a.basis_l.bases)], (a.operators..., b.operators...), a.factor*b.factor)
 
 function tr(op::LazyTensor)
     b = basis(op)
@@ -162,10 +167,7 @@ function ptrace(op::LazyTensor, indices)
     if rank==1
         return factor * identityoperator(b_l, b_r)
     end
-    ops = Vector{AbstractOperator}(undef, length(remaining_indices))
-    for i in 1:length(ops)
-        ops[i] = suboperator(op, remaining_indices[i])
-    end
+    ops = Tuple(suboperator(op, idx) for idx ∈ remaining_indices)
     LazyTensor(b_l, b_r, shiftremove(op.indices, indices), ops, factor)
 end
 
@@ -176,10 +178,10 @@ function permutesystems(op::LazyTensor, perm)
     b_r = permutesystems(op.basis_r, perm)
     indices = [findfirst(isequal(i), perm) for i in op.indices]
     perm_ = sortperm(indices)
-    LazyTensor(b_l, b_r, indices[perm_], [op.operators[perm_]...], op.factor)
+    LazyTensor(b_l, b_r, indices[perm_], op.operators[perm_], op.factor)
 end
 
-identityoperator(::Type{LazyTensor}, b1::Basis, b2::Basis) = LazyTensor(b1, b2, Int[], AbstractOperator[], 1.0)
+identityoperator(::Type{LazyTensor}, b1::Basis, b2::Basis) = LazyTensor(b1, b2, Int[], Tuple{}(), 1.0)
 
 
 # Recursively calculate result_{IK} = \\sum_J op_{IJ} h_{JK}

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -181,7 +181,7 @@ function permutesystems(op::LazyTensor, perm)
     LazyTensor(b_l, b_r, indices[perm_], op.operators[perm_], op.factor)
 end
 
-identityoperator(::Type{LazyTensor}, ::Type{T<:Number}, b1::Basis, b2::Basis) where T<:Number = LazyTensor(b1, b2, Int[], Tuple{}(), one(T))
+identityoperator(::Type{LazyTensor}, ::Type{T}, b1::Basis, b2::Basis) where T<:Number = LazyTensor(b1, b2, Int[], Tuple{}(), one(T))
 
 
 # Recursively calculate result_{IK} = \\sum_J op_{IJ} h_{JK}

--- a/test/test_abstractdata.jl
+++ b/test/test_abstractdata.jl
@@ -359,17 +359,17 @@ op2 = randtestoperator(b2a, b2b)
 op3 = randtestoperator(b3a, b3b)
 
 # Test creation
-@test_throws AssertionError LazyTensor(b_l, b_r, [1], [randtestoperator(b1a)])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [op1])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [op1, sparse(randtestoperator(b_l, b_l))])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [randtestoperator(b_r, b_r), sparse(op2)])
+@test_throws AssertionError LazyTensor(b_l, b_r, [1], (randtestoperator(b1a),))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (op1,))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (op1, sparse(randtestoperator(b_l, b_l))))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (randtestoperator(b_r, b_r), sparse(op2)))
 
 # @test LazyTensor(b_l, b_r, [2, 1], [op2, op1]) == LazyTensor(b_l, b_r, [1, 2], [op1, op2])
 x = randtestoperator(b2a)
-@test LazyTensor(b_l, 2, x) == LazyTensor(b_l, b_l, [2], [x])
+@test LazyTensor(b_l, 2, x) == LazyTensor(b_l, b_l, [2], (x,))
 
 # Test copy
-x = 2*LazyTensor(b_l, b_r, [1,2], [randtestoperator(b1a, b1b), sparse(randtestoperator(b2a, b2b))])
+x = 2*LazyTensor(b_l, b_r, [1,2], (randtestoperator(b1a, b1b), sparse(randtestoperator(b2a, b2b))))
 x_ = copy(x)
 @test x == x_
 @test !(x === x_)
@@ -383,7 +383,7 @@ x_.indices[2] = 100
 
 # Test dense & sparse
 I2 = identityoperator(b2a, b2b)
-x = LazyTensor(b_l, b_r, [1, 3], [op1, sparse(op3)], 0.3)
+x = LazyTensor(b_l, b_r, [1, 3], (op1, sparse(op3)), 0.3)
 @test D(0.3*op1⊗dense(I2)⊗op3, dense(x))
 @test D(0.3*sparse(op1)⊗I2⊗sparse(op3), sparse(x))
 
@@ -400,9 +400,9 @@ subop3 = randtestoperator(b3a, b3b)
 I1 = dense(identityoperator(b1a, b1b))
 I2 = dense(identityoperator(b2a, b2b))
 I3 = dense(identityoperator(b3a, b3b))
-op1 = LazyTensor(b_l, b_r, [1, 3], [subop1, sparse(subop3)], 0.1)
+op1 = LazyTensor(b_l, b_r, [1, 3], (subop1, sparse(subop3)), 0.1)
 op1_ = 0.1*subop1 ⊗ I2 ⊗ subop3
-op2 = LazyTensor(b_l, b_r, [2, 3], [sparse(subop2), subop3], 0.7)
+op2 = LazyTensor(b_l, b_r, [2, 3], (sparse(subop2), subop3), 0.7)
 op2_ = 0.7*I1 ⊗ subop2 ⊗ subop3
 op3 = 0.3*LazyTensor(b_l, b_r, 3, subop3)
 op3_ = 0.3*I1 ⊗ I2 ⊗ subop3

--- a/test/test_abstractdata.jl
+++ b/test/test_abstractdata.jl
@@ -364,7 +364,7 @@ op3 = randtestoperator(b3a, b3b)
 @test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [op1, sparse(randtestoperator(b_l, b_l))])
 @test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [randtestoperator(b_r, b_r), sparse(op2)])
 
-@test LazyTensor(b_l, b_r, [2, 1], [op2, op1]) == LazyTensor(b_l, b_r, [1, 2], [op1, op2])
+# @test LazyTensor(b_l, b_r, [2, 1], [op2, op1]) == LazyTensor(b_l, b_r, [1, 2], [op1, op2])
 x = randtestoperator(b2a)
 @test LazyTensor(b_l, 2, x) == LazyTensor(b_l, b_l, [2], [x])
 

--- a/test/test_operators_lazytensor.jl
+++ b/test/test_operators_lazytensor.jl
@@ -32,17 +32,17 @@ op2 = randoperator(b2a, b2b)
 op3 = randoperator(b3a, b3b)
 
 # Test creation
-@test_throws AssertionError LazyTensor(b_l, b_r, [1], [randoperator(b1a)])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [op1])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [op1, sparse(randoperator(b_l, b_l))])
-@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], [randoperator(b_r, b_r), sparse(op2)])
+@test_throws AssertionError LazyTensor(b_l, b_r, [1], (randoperator(b1a),))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (op1,))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (op1, sparse(randoperator(b_l, b_l))))
+@test_throws AssertionError LazyTensor(b_l, b_r, [1, 2], (randoperator(b_r, b_r), sparse(op2)))
 
 # @test LazyTensor(b_l, b_r, [2, 1], [op2, op1]) == LazyTensor(b_l, b_r, [1, 2], [op1, op2])
 x = randoperator(b2a)
-@test LazyTensor(b_l, 2, x) == LazyTensor(b_l, b_l, [2], [x])
+@test LazyTensor(b_l, 2, x) == LazyTensor(b_l, b_l, [2], (x,))
 
 # Test copy
-x = 2*LazyTensor(b_l, b_r, [1,2], [randoperator(b1a, b1b), sparse(randoperator(b2a, b2b))])
+x = 2*LazyTensor(b_l, b_r, [1,2], (randoperator(b1a, b1b), sparse(randoperator(b2a, b2b))))
 x_ = copy(x)
 @test x == x_
 @test !(x === x_)
@@ -56,7 +56,7 @@ x_.indices[2] = 100
 
 # Test dense & sparse
 I2 = identityoperator(b2a, b2b)
-x = LazyTensor(b_l, b_r, [1, 3], [op1, sparse(op3)], 0.3)
+x = LazyTensor(b_l, b_r, [1, 3], (op1, sparse(op3)), 0.3)
 @test 1e-12 > D(0.3*op1⊗dense(I2)⊗op3, dense(x))
 @test 1e-12 > D(0.3*sparse(op1)⊗I2⊗sparse(op3), sparse(x))
 
@@ -74,9 +74,9 @@ subop3 = randoperator(b3a, b3b)
 I1 = dense(identityoperator(b1a, b1b))
 I2 = dense(identityoperator(b2a, b2b))
 I3 = dense(identityoperator(b3a, b3b))
-op1 = LazyTensor(b_l, b_r, [1, 3], [subop1, sparse(subop3)], 0.1)
+op1 = LazyTensor(b_l, b_r, [1, 3], (subop1, sparse(subop3)), 0.1)
 op1_ = 0.1*subop1 ⊗ I2 ⊗ subop3
-op2 = LazyTensor(b_l, b_r, [2, 3], [sparse(subop2), subop3], 0.7)
+op2 = LazyTensor(b_l, b_r, [2, 3], (sparse(subop2), subop3), 0.7)
 op2_ = 0.7*I1 ⊗ subop2 ⊗ subop3
 op3 = 0.3*LazyTensor(b_l, b_r, 3, subop3)
 op3_ = 0.3*I1 ⊗ I2 ⊗ subop3
@@ -125,7 +125,7 @@ id = identityoperator(LazyTensor, b_l)
 subop1 = randoperator(b1a)
 I2 = dense(identityoperator(b2a))
 subop3 = randoperator(b3a)
-op = LazyTensor(b_l, b_l, [1, 3], [subop1, sparse(subop3)], 0.1)
+op = LazyTensor(b_l, b_l, [1, 3], (subop1, sparse(subop3)), 0.1)
 op_ = 0.1*subop1 ⊗ I2 ⊗ subop3
 
 @test tr(op) ≈ tr(op_)
@@ -141,7 +141,7 @@ normalize!(op_copy)
 subop1 = randoperator(b1a)
 I2 = dense(identityoperator(b2a))
 subop3 = randoperator(b3a)
-op = LazyTensor(b_l, b_l, [1, 3], [subop1, sparse(subop3)], 0.1)
+op = LazyTensor(b_l, b_l, [1, 3], (subop1, sparse(subop3)), 0.1)
 op_ = 0.1*subop1 ⊗ I2 ⊗ subop3
 
 @test 1e-14 > D(ptrace(op_, 3), ptrace(op, 3))
@@ -166,7 +166,7 @@ subop1 = randoperator(b1a, b1b)
 subop2 = randoperator(b2a, b2b)
 subop3 = randoperator(b3a, b3b)
 I2 = dense(identityoperator(b2a, b2b))
-op = LazyTensor(b_l, b_r, [1, 3], [subop1, sparse(subop3)])*0.1
+op = LazyTensor(b_l, b_r, [1, 3], (subop1, sparse(subop3)))*0.1
 op_ = 0.1*subop1 ⊗ I2 ⊗ subop3
 
 @test 1e-14 > D(permutesystems(op, [1, 3, 2]), permutesystems(op_, [1, 3, 2]))
@@ -181,7 +181,7 @@ subop1 = randoperator(b1a, b1b)
 subop2 = randoperator(b2a, b2b)
 subop3 = randoperator(b3a, b3b)
 I2 = dense(identityoperator(b2a, b2b))
-op = LazyTensor(b_l, b_r, [1, 3], [subop1, sparse(subop3)])*0.1
+op = LazyTensor(b_l, b_r, [1, 3], (subop1, sparse(subop3)))*0.1
 op_ = 0.1*subop1 ⊗ I2 ⊗ subop3
 
 state = Ket(b_r, rand(ComplexF64, length(b_r)))
@@ -215,7 +215,7 @@ subop1 = randoperator(b1a, b1b)
 subop2 = randoperator(b2a, b2b)
 subop3 = randoperator(b3a, b3b)
 I2 = dense(identityoperator(b2a, b2b))
-op = LazyTensor(b_l, b_r, [1, 3], [subop1, sparse(subop3)])*0.1
+op = LazyTensor(b_l, b_r, [1, 3], (subop1, sparse(subop3)))*0.1
 op_ = 0.1*subop1 ⊗ I2 ⊗ subop3
 
 state = randoperator(b_r, b_r2)
@@ -257,7 +257,7 @@ QuantumOpticsBase.mul!(result,state,op)
 
 # Test gemm errors
 test_op = test_lazytensor(b1a, b1a, rand(2, 2))
-test_lazy = LazyTensor(tensor(b1a, b1a), [1, 2], [test_op, test_op])
+test_lazy = LazyTensor(tensor(b1a, b1a), [1, 2], (test_op, test_op))
 test_ket = Ket(tensor(b1a, b1a), rand(4))
 
 @test_throws ArgumentError QuantumOpticsBase.mul!(copy(test_ket),test_lazy,test_ket,alpha,beta)

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -73,7 +73,7 @@ op = LazyProduct(SparseOperator(b_fock), DenseOperator(b_fock))
 b_fock = FockBasis(2)
 b_spin = SpinBasis(1//2)
 b_mb = ManyBodyBasis(b_spin, fermionstates(b_spin, 1))
-op = LazyTensor(b_fock ⊗ b_mb ⊗ b_spin, [1, 3], [SparseOperator(b_fock), DenseOperator(b_spin)])
+op = LazyTensor(b_fock ⊗ b_mb ⊗ b_spin, [1, 3], (SparseOperator(b_fock), DenseOperator(b_spin)))
 @test sprint(show, op) == "LazyTensor(dim=12x12)
   basis: [Fock(cutoff=2) ⊗ ManyBody(onebodybasis=Spin(1/2), states:2) ⊗ Spin(1/2)]
   operators: 2


### PR DESCRIPTION
This is actually a breaking change, since `LazyTensor` now requires the `indices` and `operators` to be sorted before construction. Previously if the arguments were unsorted, it was resorted in the constructor. Problem is, that causes type instabilities. I've never really encountered a case where unsorted arguments were important, so I'm inclined to just break it.

@amilsted you raised this issue in gitter, does that PR solve the inference problem for your use-case? Any other comments?