### PR TITLE
minor edit to SpinBasis

### DIFF
--- a/src/spin.jl
+++ b/src/spin.jl
@@ -14,7 +14,7 @@ struct SpinBasis{S,T} <: Basis
         n = numerator(spinnumber)
         d = denominator(spinnumber)
         @assert d==2 || d==1
-        @assert n > 0
+        @assert n >= 0
         N = numerator(spinnumber*2 + 1)
         new{spinnumber,T}([N], spinnumber)
     end


### PR DESCRIPTION
Suggesting a very simple change to a SpinBasis assertion to allow for spin-0. My use case has a composite system with a dynamically changing spin number, and the current workaround in the case where the spin number goes to zero is to change the definition of the composite basis to drop the SpinBasis entirely, which seems awkward as it leaves no trace that the composite system includes a spin.

This seems like a useful change for any use case that deals with an arbitrary spin number.

The standard state definitions and basic operators seem to work as expected when operating on SpinBasis(0).