### PR TITLE
Turbo complex elmul

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,439 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.2"
+manifest_format = "2.0"
+
+[[deps.AbstractFFTs]]
+deps = ["ChainRulesCore", "LinearAlgebra"]
+git-tree-sha1 = "6f1d9bc1c08f9f4a8fa92e3ea3cb50153a1b40d4"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.1.0"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.3"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.ArrayInterface]]
+deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
+git-tree-sha1 = "81f0cb60dc994ca17f68d9fb7c942a5ae70d9ee4"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "5.0.8"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BitTwiddlingConvenienceFunctions]]
+deps = ["Static"]
+git-tree-sha1 = "28bbdbf0354959db89358d1d79d421ff31ef0b5e"
+uuid = "62783981-4cbd-42fc-bca8-16325de8dc4b"
+version = "0.1.3"
+
+[[deps.CPUSummary]]
+deps = ["CpuId", "IfElse", "Static"]
+git-tree-sha1 = "baaac45b4462b3b0be16726f38b789bf330fcb7a"
+uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+version = "0.1.21"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "9950387274246d08af38f6eef8cb5480862a435f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.14.0"
+
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "1e315e3f4b0b7ce40feded39c73049692126cf53"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.3"
+
+[[deps.CloseOpenIntervals]]
+deps = ["ArrayInterface", "Static"]
+git-tree-sha1 = "f576084239e6bdf801007c80e27e2cc2cd963fe0"
+uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
+version = "0.1.6"
+
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.0"
+
+[[deps.Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "b153278a25dd42c65abbf4e62344f9d22e59191b"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.43.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.CpuId]]
+deps = ["Markdown"]
+git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+version = "0.3.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[deps.DiffResults]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.0.3"
+
+[[deps.DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "28d605d9a0ac17118fe2c5e9ce0fbb76c3ceb120"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.11.0"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
+git-tree-sha1 = "505876577b5481e50d089c1c68899dfb6faebc62"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.4.6"
+
+[[deps.FFTW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.10+0"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "89cc49bf5819f0a10a7a3c38885e7c7ee048de57"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.29"
+
+[[deps.HostCPUFeatures]]
+deps = ["BitTwiddlingConvenienceFunctions", "IfElse", "Libdl", "Static"]
+git-tree-sha1 = "18be5268cf415b5e27f34980ed25a7d34261aa83"
+uuid = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+version = "0.1.7"
+
+[[deps.Hwloc]]
+deps = ["Hwloc_jll"]
+git-tree-sha1 = "92d99146066c5c6888d5a3abc871e6a214388b91"
+uuid = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
+version = "2.0.0"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "303d70c961317c4c20fafaf5dbe0e6d610c38542"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.7.1+0"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
+[[deps.IntelOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d979e54b71da82f3a65b62553da4fc3d18c9004c"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2018.0.3+2"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "336cc738f03e069ef2cac55a104eb823455dca75"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.4"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
+[[deps.LayoutPointers]]
+deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static"]
+git-tree-sha1 = "b651f573812d6c36c22c944dd66ef3ab2283dfa1"
+uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
+version = "0.1.6"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "09e4b894ce6a976c354a69041a04748180d43637"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.15"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.LoopVectorization]]
+deps = ["ArrayInterface", "CPUSummary", "ChainRulesCore", "CloseOpenIntervals", "DocStringExtensions", "ForwardDiff", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "SIMDDualNumbers", "SLEEFPirates", "SpecialFunctions", "Static", "ThreadingUtilities", "UnPack", "VectorizationBase"]
+git-tree-sha1 = "2c7b360d8b620a28c77ff6275f5612d4d6446942"
+uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
+version = "0.12.109"
+
+[[deps.MKL_jll]]
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
+git-tree-sha1 = "e595b205efd49508358f7dc670a940c790204629"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2022.0.0+0"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.9"
+
+[[deps.ManualMemory]]
+git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
+uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
+version = "0.1.8"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NaNMath]]
+git-tree-sha1 = "737a5957f387b17e74d4ad2f440eb330b39a62c5"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.0.0"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "aee446d0b3d5764e35289762f6a18e8ea041a592"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.11.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.PolyesterWeave]]
+deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
+git-tree-sha1 = "7e597df97e46ffb1c8adbaddfa56908a7a20194b"
+uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+version = "0.1.5"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.3.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.SIMDDualNumbers]]
+deps = ["ForwardDiff", "IfElse", "SLEEFPirates", "VectorizationBase"]
+git-tree-sha1 = "62c2da6eb66de8bb88081d20528647140d4daa0e"
+uuid = "3cdde19b-5bb0-4aaf-8931-af3e248e098b"
+version = "0.1.0"
+
+[[deps.SIMDTypes]]
+git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
+uuid = "94e857df-77ce-4151-89e5-788b33177be4"
+version = "0.1.0"
+
+[[deps.SLEEFPirates]]
+deps = ["IfElse", "Static", "VectorizationBase"]
+git-tree-sha1 = "ac399b5b163b9140f9c310dfe9e9aaa225617ff6"
+uuid = "476501e8-09a2-5ece-8869-fb82de89a1fa"
+version = "0.6.32"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "5ba658aeecaaf96923dce0da9e703bd1fe7666f9"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.1.4"
+
+[[deps.Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "5309da1cdef03e95b73cd3251ac3a39f887da53e"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.6.4"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "cd56bf18ed715e8b09f06ef8c6b781e6cdc49911"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.ThreadingUtilities]]
+deps = ["ManualMemory"]
+git-tree-sha1 = "f8629df51cab659d70d2e5618a430b4d3f37f2c3"
+uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
+version = "0.5.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.VectorizationBase]]
+deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "Hwloc", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
+git-tree-sha1 = "ff34c2f1d80ccb4f359df43ed65d6f90cb70b323"
+uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+version = "0.21.31"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "v0.3.1"
+version = "0.3.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -515,9 +515,10 @@ function mul!(result::Ket{B1},M::FFTOperator{B1,B2},b::Ket{B2},alpha,beta) where
         # end
     else
         psi_ = Ket(M.basis_l, copy(b.data))
-        @inbounds for i=1:N
-            psi_.data[i] *= M.mul_before[i]
-        end
+        cvec_elmul!(psi_.data, psi_.data, M.mul_before)
+        # @inbounds for i=1:N
+        #     psi_.data[i] *= M.mul_before[i]
+        # end
         M.fft_r! * reshape(psi_.data, size(M.mul_before))
         @inbounds for i=1:N
             result.data[i] = beta*result.data[i] + alpha * psi_.data[i] * M.mul_after[i]

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -501,8 +501,7 @@ dagger(op::FFTKets) = transform(op.basis_r, op.basis_l; ket_only=true)
 tensor(A::FFTOperators, B::FFTOperators) = transform(tensor(A.basis_l, B.basis_l), tensor(A.basis_r, B.basis_r))
 tensor(A::FFTKets, B::FFTKets) = transform(tensor(A.basis_l, B.basis_l), tensor(A.basis_r, B.basis_r); ket_only=true)
 
-function mul!(result::Ket{B1},M::FFTOperator{B1,B2},b::Ket{B2},alpha,beta) where {B1,B2}
-    N = length(M.basis_r)
+function mul!(result::Ket{B1},M::FFTOperator{B1,B2},b::Ket{B2},alpha,beta) where {B1,B2}    
     if iszero(beta)
         cvec_elmul!(result.data, M.mul_before, b.data)
         # @inbounds for i=1:N
@@ -514,6 +513,7 @@ function mul!(result::Ket{B1},M::FFTOperator{B1,B2},b::Ket{B2},alpha,beta) where
         #     result.data[i] *= M.mul_after[i] * alpha
         # end
     else
+        N = length(M.basis_r)
         psi_ = Ket(M.basis_l, copy(b.data))
         cvec_elmul!(psi_.data, psi_.data, M.mul_before)
         # @inbounds for i=1:N

--- a/src/turbo.jl
+++ b/src/turbo.jl
@@ -3,9 +3,9 @@ function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex
     return cvec_elmul!(cc, ca, cb, true)
 end
 function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, alpha::Union{Real,Bool}) where {T,N1,N2,N3}
-    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
-    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
-    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
+    c = reinterpret(reshape, T,  vec(cc))
+    a = reinterpret(reshape, T,  vec(ca))
+    b = reinterpret(reshape, T,  vec(cb))
     re = zero(T)
     im = zero(T)
     @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))
@@ -17,9 +17,9 @@ function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex
 end
 
 function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, calpha::Complex{T}) where {T,N1,N2,N3}
-    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
-    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
-    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
+    c = reinterpret(reshape, T,  vec(cc))
+    a = reinterpret(reshape, T,  vec(ca))
+    b = reinterpret(reshape, T,  vec(cb))
     re = zero(T)
     im = zero(T)
     @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))

--- a/src/turbo.jl
+++ b/src/turbo.jl
@@ -1,14 +1,14 @@
 using LoopVectorization
-function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}) where {T}
+function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}) where {T,N1,N2,N3}
     return cvec_elmul!(cc, ca, cb, true)
 end
-function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}, alpha::Union{Real,Bool}) where {T}
-    c = reinterpret(reshape, T, cc)
-    a = reinterpret(reshape, T, ca)
-    b = reinterpret(reshape, T, cb)
+function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, alpha::Union{Real,Bool}) where {T,N1,N2,N3}
+    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
+    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
+    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
     re = zero(T)
     im = zero(T)
-    @tturbo for i in eachindex(cc, ca, cb)
+    @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))
         re = a[1, i] * b[1, i] - a[2, i] * b[2, i]
         im = a[1, i] * b[2, i] + a[2, i] * b[1, i]
         c[1,i]=re * alpha
@@ -16,13 +16,13 @@ function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{
     end
 end
 
-function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}, calpha::Complex{T}) where {T}
-    c = reinterpret(reshape, T, cc)
-    a = reinterpret(reshape, T, ca)
-    b = reinterpret(reshape, T, cb)
+function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, calpha::Complex{T}) where {T,N1,N2,N3}
+    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
+    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
+    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
     re = zero(T)
     im = zero(T)
-    @tturbo for i in eachindex(cc, ca, cb)
+    @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))
         re = a[1, i] * b[1, i] - a[2, i] * b[2, i]
         im = a[1, i] * b[2, i] + a[2, i] * b[1, i]
         c[1,i]=re * calpha.re - im * calpha.im

--- a/src/turbo.jl
+++ b/src/turbo.jl
@@ -3,9 +3,9 @@ function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex
     return cvec_elmul!(cc, ca, cb, true)
 end
 function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, alpha::Union{Real,Bool}) where {T,N1,N2,N3}
-    c = reinterpret(reshape, T,  vec(cc))
-    a = reinterpret(reshape, T,  vec(ca))
-    b = reinterpret(reshape, T,  vec(cb))
+    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
+    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
+    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
     re = zero(T)
     im = zero(T)
     @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))
@@ -17,9 +17,9 @@ function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex
 end
 
 function cvec_elmul!(cc::AbstractArray{Complex{T},N1}, ca::AbstractArray{Complex{T},N2}, cb::AbstractArray{Complex{T},N3}, calpha::Complex{T}) where {T,N1,N2,N3}
-    c = reinterpret(reshape, T,  vec(cc))
-    a = reinterpret(reshape, T,  vec(ca))
-    b = reinterpret(reshape, T,  vec(cb))
+    c = reinterpret(reshape, T,  vec(view(cc,ntuple(i->:,N1)...)))
+    a = reinterpret(reshape, T,  vec(view(ca,ntuple(i->:,N2)...)))
+    b = reinterpret(reshape, T,  vec(view(cb,ntuple(i->:,N3)...)))
     re = zero(T)
     im = zero(T)
     @tturbo for i in eachindex(axes(c,2), axes(a,2), axes(b,2))

--- a/src/turbo.jl
+++ b/src/turbo.jl
@@ -1,0 +1,31 @@
+using LoopVectorization
+function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}) where {T}
+    return cvec_elmul!(cc, ca, cb, true)
+end
+function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}, alpha::Union{Real,Bool}) where {T}
+    c = reinterpret(reshape, T, cc)
+    a = reinterpret(reshape, T, ca)
+    b = reinterpret(reshape, T, cb)
+    re = zero(T)
+    im = zero(T)
+    @tturbo for i in eachindex(cc, ca, cb)
+        re = a[1, i] * b[1, i] - a[2, i] * b[2, i]
+        im = a[1, i] * b[2, i] + a[2, i] * b[1, i]
+        c[1,i]=re * alpha
+        c[2,i]=im * alpha
+    end
+end
+
+function cvec_elmul!(cc::AbstractVector{Complex{T}}, ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}, calpha::Complex{T}) where {T}
+    c = reinterpret(reshape, T, cc)
+    a = reinterpret(reshape, T, ca)
+    b = reinterpret(reshape, T, cb)
+    re = zero(T)
+    im = zero(T)
+    @tturbo for i in eachindex(cc, ca, cb)
+        re = a[1, i] * b[1, i] - a[2, i] * b[2, i]
+        im = a[1, i] * b[2, i] + a[2, i] * b[1, i]
+        c[1,i]=re * calpha.re - im * calpha.im
+        c[2,i]=im * calpha.re + re * calpha.im
+    end
+end


### PR DESCRIPTION
Threaded way to gain speed up using LoopVectorization when mul! FFT operators.

Vector length 2^14

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  56.900 μs … 195.600 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     74.100 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   73.955 μs ±   6.506 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▁▄▅▃▃    ▂▃▅▆█▇▃▁
  ▁▁▁▂▃▂▂▁▁▂▂▂▂▃▃▂▆███████▆▇█████████▇▇▇▇▆▆▅▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  56.9 μs         Histogram: frequency by time         92.8 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

after turbo:
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  40.900 μs …  1.389 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     52.800 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   58.893 μs ± 40.906 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▃▆▇█▇▇▆▅▄▃▂▂▁ ▁▁▁▁▁                                       ▂
  █▇██████████████████████▇▇▇▇█▇▆▆▆▅▄▆▆▅▄▄▄▄▅▄▅▄▄▄▃▅▃▄▅▄▄▃▄▃▄ █
  40.9 μs      Histogram: log(frequency) by time       152 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```