### PR TITLE
Faster lazy ops

### DIFF
--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -34,12 +34,14 @@ LazySum(::Type{T}, basis_l::Basis, basis_r::Basis) where T = LazySum(basis_l,bas
 LazySum(basis_l::Basis, basis_r::Basis) = LazySum(ComplexF64, basis_l, basis_r)
 
 function LazySum(factors, operators)
+    if operators isa AbstractVector
+        @info "LazySum operators with vector storage of operators may not perform well in time evolution."
+    end
     Tf = promote_type(eltype(factors), mapreduce(eltype, promote_type, operators))
     factors_ = eltype(factors) != Tf ? Tf.(factors) : factors
     LazySum(operators[1].basis_l, operators[1].basis_r, factors_, operators)
 end
 LazySum(operators::AbstractOperator...) = LazySum(ones(ComplexF64, length(operators)), (operators...,))
-LazySum(factors, operators::Vector) = LazySum(factors, (operators...,))
 LazySum() = throw(ArgumentError("LazySum needs a basis, or at least one operator!"))
 
 Base.copy(x::LazySum) = LazySum(copy(x.factors), ([copy(op) for op in x.operators]...,))

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -51,7 +51,7 @@ LazySum(operators::AbstractOperator...) = LazySum(ComplexF64, operators...)
 LazySum() = throw(ArgumentError("LazySum needs a basis, or at least one operator!"))
 
 Base.copy(x::LazySum) = LazySum(x.basis_l, x.basis_r, copy(x.factors), copy.(x.operators); skip_checks=true)
-Base.eltype(x::LazySum) = promote_type(eltype(x.factors), eltype.(x.operators)...)
+Base.eltype(x::LazySum) = promote_type(eltype(x.factors), mapreduce(eltype, promote_type, x.operators))
 
 dense(op::LazySum) = length(op.operators) > 0 ? sum(op.factors .* dense.(op.operators)) : Operator(op.basis_l, op.basis_r, zeros(eltype(op.factors), length(op.basis_l), length(op.basis_r)))
 SparseArrays.sparse(op::LazySum) = length(op.operators) > 0 ? sum(op.factors .* sparse.(op.operators)) : Operator(op.basis_l, op.basis_r, spzeros(eltype(op.factors), length(op.basis_l), length(op.basis_r)))
@@ -59,6 +59,7 @@ SparseArrays.sparse(op::LazySum) = length(op.operators) > 0 ? sum(op.factors .* 
 isequal(x::LazySum, y::LazySum) = samebases(x,y) && isequal(x.operators, y.operators) && isequal(x.factors, y.factors)
 ==(x::LazySum, y::LazySum) = (samebases(x,y) && x.operators==y.operators && x.factors==y.factors)
 
+# Make tuples contagious in LazySum arithmetic, but preserve "vector-only" cases
 _cat(opsA::Tuple, opsB::Tuple) = (opsA..., opsB...)
 _cat(opsA::Tuple, opsB) = (opsA..., opsB...)
 _cat(opsA, opsB::Tuple) = (opsA..., opsB...)

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -36,7 +36,7 @@ function LazySum(::Type{Tf}, factors, operators) where Tf
     LazySum(operators[1].basis_l, operators[1].basis_r, factors_, operators)
 end
 function LazySum(factors, operators)
-    Tf = promote_type(eltype(factors), mapreduce(eltype, promote_type, AbstractOperator[operators...]))
+    Tf = promote_type(eltype(factors), mapreduce(eltype, promote_type, operators))
     LazySum(Tf, factors, operators)
 end
 LazySum(operators::AbstractOperator...) = LazySum(ones(ComplexF64, length(operators)), (operators...,))

--- a/test/test_operators_lazysum.jl
+++ b/test/test_operators_lazysum.jl
@@ -42,9 +42,9 @@ op1 = randoperator(b_l, b_r)
 op2 = sparse(randoperator(b_l, b_r))
 @test 0.1*op1 == dense(LazySum([0.1], (op1,)))
 @test 0.3*op2 == sparse(LazySum([0.3], (op2,)))
-@test 0.1*sparse(op1) + 0.3*op2 == sparse(LazySum([0.1, 0.3], [op1, op2]))
-@test 0.1*op1 + 0.3*dense(op2) == dense(LazySum([0.1, 0.3], [op1, op2]))
-@test 0.1*sparse(op1) + 0.3*op2 == sparse(LazySum([0.1, 0.3], [op1, op2]))
+@test 0.1*sparse(op1) + 0.3*op2 == sparse(LazySum([0.1, 0.3], (op1, op2)))
+@test 0.1*op1 + 0.3*dense(op2) == dense(LazySum([0.1, 0.3], (op1, op2)))
+@test 0.1*sparse(op1) + 0.3*op2 == sparse(LazySum([0.1, 0.3], (op1, op2)))
 
 # Test embed
 x1 = randoperator(b1a,b1b)
@@ -85,8 +85,8 @@ xbra1 = Bra(b_l, rand(ComplexF64, length(b_l)))
 
 # Test multiplication
 @test_throws ArgumentError op1*op2
-@test LazySum([0.1, 0.1], [op1a, op2a]) == LazySum(op1a, op2a)*0.1
-@test LazySum([0.1, 0.1], [op1a, op2a]) == 0.1*LazySum(op1a, op2a)
+@test LazySum([0.1, 0.1], (op1a, op2a)) == LazySum(op1a, op2a)*0.1
+@test LazySum([0.1, 0.1], (op1a, op2a)) == 0.1*LazySum(op1a, op2a)
 @test 1e-11 > D(op1*(x1 + 0.3*x2), op1_*(x1 + 0.3*x2))
 @test 1e-11 > D(op1*x1 + 0.3*op1*x2, op1_*x1 + 0.3*op1_*x2)
 @test 1e-11 > D((op1+op2)*(x1+0.3*x2), (op1_+op2_)*(x1+0.3*x2))
@@ -112,7 +112,7 @@ id = identityoperator(LazySum, b_l)
 op1 = randoperator(b_l)
 op2 = randoperator(b_l)
 op3 = randoperator(b_l)
-op = LazySum([0.1, 0.3, 1.2], [op1, op2, op3])
+op = LazySum([0.1, 0.3, 1.2], (op1, op2, op3))
 op_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 
 @test tr(op_) ≈ tr(op)
@@ -130,7 +130,7 @@ normalize!(op_copy)
 op1 = randoperator(b_l)
 op2 = randoperator(b_l)
 op3 = randoperator(b_l)
-op123 = LazySum([0.1, 0.3, 1.2], [op1, op2, op3])
+op123 = LazySum([0.1, 0.3, 1.2], (op1, op2, op3))
 op123_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 
 @test 1e-14 > D(ptrace(op123_, 3), ptrace(op123, 3))
@@ -177,7 +177,7 @@ op_ = 0.3*op123a + 0.7*op123b + 1.2*op123c
 op1 = randoperator(b_l, b_r)
 op2 = randoperator(b_l, b_r)
 op3 = randoperator(b_l, b_r)
-op = LazySum([0.1, 0.3, 1.2], [op1, op2, op3])
+op = LazySum([0.1, 0.3, 1.2], (op1, op2, op3))
 op_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 
 zero_op = LazySum(b_l, b_r)
@@ -224,7 +224,7 @@ QuantumOpticsBase.mul!(result,state,op,alpha,beta)
 op1 = randoperator(b_l, b_r)
 op2 = randoperator(b_l, b_r)
 op3 = randoperator(b_l, b_r)
-op = LazySum([0.1, 0.3, 1.2], [op1, op2, op3])
+op = LazySum([0.1, 0.3, 1.2], (op1, op2, op3))
 op_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 
 state = randoperator(b_r, b_r)

--- a/test/test_operators_lazysum.jl
+++ b/test/test_operators_lazysum.jl
@@ -62,7 +62,7 @@ op1b = randoperator(b_l, b_r)
 op2a = randoperator(b_l, b_r)
 op2b = randoperator(b_l, b_r)
 op3a = randoperator(b_l, b_r)
-op1 = LazySum([0.1, 0.3], [op1a, sparse(op1b)])
+op1 = LazySum([0.1, 0.3], (op1a, sparse(op1b)))
 op1_ = 0.1*op1a + 0.3*op1b
 op2 = LazySum([0.7, 0.9], [sparse(op2a), op2b])
 op2_ = 0.7*op2a + 0.9*op2b
@@ -94,6 +94,12 @@ xbra1 = Bra(b_l, rand(ComplexF64, length(b_l)))
 
 # Test division
 @test 1e-14 > D(op1/7, op1_/7)
+
+# Test tuples vs. vectors
+@test (op1+op1).operators isa Tuple
+@test (op1+op2).operators isa Tuple
+@test (op2+op1).operators isa Tuple
+@test (op2+op2).operators isa Vector
 
 # Test identityoperator
 Idense = identityoperator(DenseOpType, b_r)
@@ -131,6 +137,7 @@ op1 = randoperator(b_l)
 op2 = randoperator(b_l)
 op3 = randoperator(b_l)
 op123 = LazySum([0.1, 0.3, 1.2], (op1, op2, op3))
+op123_v = LazySum([0.1, 0.3, 1.2], [op1, op2, op3])
 op123_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 
 @test 1e-14 > D(ptrace(op123_, 3), ptrace(op123, 3))
@@ -140,6 +147,8 @@ op123_ = 0.1*op1 + 0.3*op2 + 1.2*op3
 @test 1e-14 > D(ptrace(op123_, [2,3]), ptrace(op123, [2,3]))
 @test 1e-14 > D(ptrace(op123_, [1,3]), ptrace(op123, [1,3]))
 @test 1e-14 > D(ptrace(op123_, [1,2]), ptrace(op123, [1,2]))
+
+@test 1e-14 > D(ptrace(op123_v, [1,2]), ptrace(op123, [1,2]))
 
 @test_throws ArgumentError ptrace(op123, [1,2,3])
 

--- a/test/test_operators_lazytensor.jl
+++ b/test/test_operators_lazytensor.jl
@@ -61,6 +61,9 @@ x = LazyTensor(b_l, b_r, [1, 3], (op1, sparse(op3)), 0.3)
 @test 1e-12 > D(0.3*op1⊗dense(I2)⊗op3, dense(x))
 @test 1e-12 > D(0.3*sparse(op1)⊗I2⊗sparse(op3), sparse(x))
 
+# Test eltype
+@test eltype(x) == ComplexF64
+
 # Test suboperators
 @test QuantumOpticsBase.suboperator(x, 1) == op1
 @test QuantumOpticsBase.suboperator(x, 3) == sparse(op3)


### PR DESCRIPTION
Reduce compile time of some lazy op arithmetic ops.

For example
```
ls = LazySum(b, b)
op = LazySum(randoperator(b))

@time for _ in 1:N  # compilation time scales with N
    ls += op  # every `+` will require compilation, as the first argument changes type each iteration
end
```