### PR TITLE
add JET and Aqua static analysis tests

### DIFF
--- a/.github/workflows/ci-jet.yml
+++ b/.github/workflows/ci-jet.yml
@@ -1,0 +1,48 @@
+name: CI with JET
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - nightly
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+        arch:
+          - x64
+          - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          QUANTUMSAVORY_JET_TEST: true
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/ci-jet.yml
+++ b/.github/workflows/ci-jet.yml
@@ -14,14 +14,8 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - windows-latest
-          - macOS-latest
         arch:
           - x64
-          - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ julia = "1.3"
 [extras]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
@@ -34,4 +35,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["LinearAlgebra", "SparseArrays", "Random", "Test", "Aqua", "JET", "Adapt", "FFTW", "LRUCache", "Strided", "UnsafeArrays"]
+test = ["LinearAlgebra", "SparseArrays", "Random", "Test", "Aqua", "JET", "Adapt", "Dates", "FFTW", "LRUCache", "Strided", "UnsafeArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -21,10 +21,17 @@ UnsafeArrays = "1"
 julia = "1.3"
 
 [extras]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [targets]
-test = ["LinearAlgebra", "SparseArrays", "Random", "Test"]
+test = ["LinearAlgebra", "SparseArrays", "Random", "Test", "Aqua", "JET", "Adapt", "FFTW", "LRUCache", "Strided", "UnsafeArrays"]

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -3,31 +3,46 @@ module QuantumOpticsBase
 using SparseArrays, LinearAlgebra, LRUCache, Strided, UnsafeArrays
 import LinearAlgebra: mul!, rmul!
 
-export bases, Basis, GenericBasis, CompositeBasis, basis,
+export Basis, GenericBasis, CompositeBasis, basis,
         tensor, ⊗, permutesystems, @samebases,
-        states, StateVector, Bra, Ket, basisstate, sparsebasisstate, norm,
+        #states
+                StateVector, Bra, Ket, basisstate, sparsebasisstate, norm,
                 dagger, normalize, normalize!,
-        operators, AbstractOperator, DataOperator, expect, variance,
-            identityoperator, ptrace, reduced, embed, dense, tr, sparse,
-        operators_dense, Operator, DenseOperator, DenseOpType, projector, dm,
-        operators_sparse, SparseOperator, diagonaloperator, SparseOpType,
-        operators_lazysum, LazySum,
-        operators_lazyproduct, LazyProduct,
-        operators_lazytensor, LazyTensor, lazytensor_use_cache, lazytensor_clear_cache,
-        lazytensor_cachesize, lazytensor_disable_cache, lazytensor_enable_cache,
-        superoperators, SuperOperator, DenseSuperOperator, DenseSuperOpType,
+        #operators
+                AbstractOperator, DataOperator, expect, variance,
+                identityoperator, ptrace, reduced, embed, dense, tr, sparse,
+        #operators_dense
+                Operator, DenseOperator, DenseOpType, projector, dm,
+        #operators_sparse
+                SparseOperator, diagonaloperator, SparseOpType,
+        #operators_lazysum
+                LazySum,
+        #operators_lazyproduct
+                LazyProduct,
+        #operators_lazytensor
+                LazyTensor, lazytensor_use_cache, lazytensor_clear_cache,
+                lazytensor_cachesize, lazytensor_disable_cache, lazytensor_enable_cache,
+        #superoperators
+                SuperOperator, DenseSuperOperator, DenseSuperOpType,
                 SparseSuperOperator, SparseSuperOpType, spre, spost, liouvillian,
-        fock, FockBasis, number, destroy, create,
+        #fock
+                FockBasis, number, destroy, create,
                 fockstate, coherentstate, coherentstate!, displace,
         randstate, randoperator, thermalstate, coherentthermalstate, phase_average, passive_state,
-        spin, SpinBasis, sigmax, sigmay, sigmaz, sigmap, sigmam, spinup, spindown,
-        subspace, SubspaceBasis, projector, sparseprojector,
-        particle, PositionBasis, MomentumBasis, samplepoints, spacing, gaussianstate,
+        #spin
+                SpinBasis, sigmax, sigmay, sigmaz, sigmap, sigmam, spinup, spindown,
+        #subspace
+                SubspaceBasis, projector, sparseprojector,
+        #particle
+                PositionBasis, MomentumBasis, samplepoints, spacing, gaussianstate,
                 position, momentum, potentialoperator, transform,
-        nlevel, NLevelBasis, transition, nlevelstate,
-        manybody, ManyBodyBasis, fermionstates, bosonstates,
-                manybodyoperator, onebodyexpect, occupation,
-        metrics, tracenorm, tracenorm_h, tracenorm_nh,
+        #nlevel
+                NLevelBasis, transition, nlevelstate,
+        #manybody
+                ManyBodyBasis, fermionstates, bosonstates,
+                manybodyoperator, onebodyexpect,
+        #metrics
+                tracenorm, tracenorm_h, tracenorm_nh,
                 tracedistance, tracedistance_h, tracedistance_nh,
                 entropy_vn, entropy_renyi, fidelity, ptranspose, PPT,
                 negativity, logarithmic_negativity, entanglement_entropy,

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -28,8 +28,8 @@ Generate all fermionic occupation states for N-particles in M-modes.
 `Nparticles` can be a vector to define a Hilbert space with variable
 particle number.
 """
-fermionstates(Nmodes::T, Nparticles::T) where T = _distribute_fermions(Nparticles, Nmodes, 1, zeros(Int, Nmodes), Vector{Int}[])
-fermionstates(Nmodes::T, Nparticles::Vector{T}) where T = vcat([fermionstates(Nmodes, N) for N in Nparticles]...)
+fermionstates(Nmodes::Int, Nparticles::Int) = _distribute_fermions(Nparticles, Nmodes, 1, zeros(Int, Nmodes), Vector{Int}[])
+fermionstates(Nmodes::Int, Nparticles::Vector{Int}) = vcat([fermionstates(Nmodes, N) for N in Nparticles]...)
 fermionstates(onebodybasis::Basis, Nparticles) = fermionstates(length(onebodybasis), Nparticles)
 
 """
@@ -40,8 +40,8 @@ Generate all bosonic occupation states for N-particles in M-modes.
 `Nparticles` can be a vector to define a Hilbert space with variable
 particle number.
 """
-bosonstates(Nmodes::T, Nparticles::T) where T = _distribute_bosons(Nparticles, Nmodes, 1, zeros(Int, Nmodes), Vector{Int}[])
-bosonstates(Nmodes::T, Nparticles::Vector{T}) where T = vcat([bosonstates(Nmodes, N) for N in Nparticles]...)
+bosonstates(Nmodes::Int, Nparticles::Int) = _distribute_bosons(Nparticles, Nmodes, 1, zeros(Int, Nmodes), Vector{Int}[])
+bosonstates(Nmodes::Int, Nparticles::Vector{Int}) = vcat([bosonstates(Nmodes, N) for N in Nparticles]...)
 bosonstates(onebodybasis::Basis, Nparticles) = bosonstates(length(onebodybasis), Nparticles)
 
 ==(b1::ManyBodyBasis, b2::ManyBodyBasis) = b1.occupations_hash==b2.occupations_hash && b1.onebodybasis==b2.onebodybasis

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -191,7 +191,7 @@ function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
     data[1] = one(Tnum)
     i = N
     while i > 0
-        if i ∈ index
+        if i == index
             data = kron(data, op.data)
             i -= length(index)
         else

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -215,13 +215,13 @@ specifies in which subsystems the corresponding operator is defined.
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
                operators::Dict{<:Vector{<:Integer}, T}) where T<:AbstractOperator
     @assert length(basis_l.bases) == length(basis_r.bases)
-    N = length(basis_l.bases)
+    N = length(basis_l.bases)::Int # type assertion to help type inference
     if length(operators) == 0
         return identityoperator(T, basis_l, basis_r)
     end
     indices, operator_list = zip(operators...)
     operator_list = [operator_list...;]
-    indices_flat = [indices...;]
+    indices_flat = [indices...;]::Vector{Int} # type assertion to help type inference
     start_indices_flat = [i[1] for i in indices]
     complement_indices_flat = Int[i for i=1:N if i ∉ indices_flat]
     operators_flat = AbstractOperator[]

--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -78,8 +78,8 @@ Base.isapprox(x::DataOperator, y::DataOperator; kwargs...) = false
 *(a::Bra, b::DataOperator) = throw(IncompatibleBases())
 *(a::Operator{B1,B2}, b::Operator{B2,B3}) where {B1,B2,B3} = Operator(a.basis_l, b.basis_r, a.data*b.data)
 *(a::DataOperator, b::DataOperator) = throw(IncompatibleBases())
-*(a::DataOperator{B1, B2}, b::Operator{B2, B3, T}) where {B1, B2, B3, T} = throw(error("no `*` method defined for DataOperator subtype $(typeof(a))")) # defined to avoid method ambiguity
-*(a::Operator{B1, B2, T}, b::DataOperator{B2, B3}) where {B1, B2, B3, T} = throw(error("no `*` method defined for DataOperator subtype $(typeof(b))")) # defined to avoid method ambiguity
+*(a::DataOperator{B1, B2}, b::Operator{B2, B3, T}) where {B1, B2, B3, T} = error("no `*` method defined for DataOperator subtype $(typeof(a))") # defined to avoid method ambiguity
+*(a::Operator{B1, B2, T}, b::DataOperator{B2, B3}) where {B1, B2, B3, T} = error("no `*` method defined for DataOperator subtype $(typeof(b))") # defined to avoid method ambiguity
 *(a::Operator, b::Number) = Operator(a.basis_l, a.basis_r, b*a.data)
 *(a::Number, b::Operator) = Operator(b.basis_l, b.basis_r, a*b.data)
 function *(op1::AbstractOperator{B1,B2}, op2::Operator{B2,B3,T}) where {B1,B2,B3,T}

--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -78,6 +78,8 @@ Base.isapprox(x::DataOperator, y::DataOperator; kwargs...) = false
 *(a::Bra, b::DataOperator) = throw(IncompatibleBases())
 *(a::Operator{B1,B2}, b::Operator{B2,B3}) where {B1,B2,B3} = Operator(a.basis_l, b.basis_r, a.data*b.data)
 *(a::DataOperator, b::DataOperator) = throw(IncompatibleBases())
+*(a::DataOperator{B1, B2}, b::Operator{B2, B3, T}) where {B1, B2, B3, T} = throw(error("no `*` method defined for DataOperator subtype $(typeof(a))")) # defined to avoid method ambiguity
+*(a::Operator{B1, B2, T}, b::DataOperator{B2, B3}) where {B1, B2, B3, T} = throw(error("no `*` method defined for DataOperator subtype $(typeof(b))")) # defined to avoid method ambiguity
 *(a::Operator, b::Number) = Operator(a.basis_l, a.basis_r, b*a.data)
 *(a::Number, b::Operator) = Operator(b.basis_l, b.basis_r, a*b.data)
 function *(op1::AbstractOperator{B1,B2}, op2::Operator{B2,B3,T}) where {B1,B2,B3,T}
@@ -379,6 +381,7 @@ end
 # Broadcasting
 Base.size(A::DataOperator) = size(A.data)
 Base.size(A::DataOperator, d) = size(A.data, d)
+Base.size(A::DataOperator, d::Int) = size(A.data, d) # defined to avoid method ambiguity
 @inline Base.axes(A::DataOperator) = axes(A.data)
 Base.broadcastable(A::DataOperator) = A
 
@@ -403,9 +406,6 @@ const BasicMathFunc = Union{typeof(+),typeof(-),typeof(*)}
 function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{Vararg{<:DataOperator}}, axes)
     args_ = Tuple(a.data for a=args)
     return Broadcast.Broadcasted(f, args_, axes)
-end
-function Broadcasted_restrict_f(f, args::Tuple{Vararg{<:DataOperator}}, axes)
-    throw(error("Cannot broadcast function `$f` on type `$(eltype(args))`"))
 end
 
 # In-place broadcasting

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -129,10 +129,9 @@ end
 
 identityoperator(::Type{<:LazySum}, ::Type{S}, b1::Basis, b2::Basis) where S<:Number = LazySum(identityoperator(S, b1, b2))
 
-function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazySum)
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices::AbstractVector, op::LazySum)
     LazySum(basis_l, basis_r, op.factors, ((embed(basis_l, basis_r, indices, o) for o in op.operators)...,))
 end
-embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum) = error("nesting one `CompositeBasis` in another requires more than one index")
 
 # Fast in-place multiplication
 function mul!(result::Ket{B1},a::LazySum{B1,B2},b::Ket{B2},alpha,beta) where {B1,B2}

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -132,7 +132,7 @@ identityoperator(::Type{<:LazySum}, ::Type{S}, b1::Basis, b2::Basis) where S<:Nu
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazySum)
     LazySum(basis_l, basis_r, op.factors, ((embed(basis_l, basis_r, indices, o) for o in op.operators)...,))
 end
-embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum) = embed(basis_l, basis_r, [i], op)
+embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum) = error("nesting one `CompositeBasis` in another requires more than one index")
 
 # Fast in-place multiplication
 function mul!(result::Ket{B1},a::LazySum{B1,B2},b::Ket{B2},alpha,beta) where {B1,B2}

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -132,6 +132,7 @@ identityoperator(::Type{<:LazySum}, ::Type{S}, b1::Basis, b2::Basis) where S<:Nu
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazySum)
     LazySum(basis_l, basis_r, op.factors, ((embed(basis_l, basis_r, indices, o) for o in op.operators)...,))
 end
+embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum) = embed(basis_l, basis_r, [i], op)
 
 # Fast in-place multiplication
 function mul!(result::Ket{B1},a::LazySum{B1,B2},b::Ket{B2},alpha,beta) where {B1,B2}

--- a/src/operators_lazysum.jl
+++ b/src/operators_lazysum.jl
@@ -129,8 +129,11 @@ end
 
 identityoperator(::Type{<:LazySum}, ::Type{S}, b1::Basis, b2::Basis) where S<:Number = LazySum(identityoperator(S, b1, b2))
 
-function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices::AbstractVector, op::LazySum)
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazySum)
     LazySum(basis_l, basis_r, op.factors, ((embed(basis_l, basis_r, indices, o) for o in op.operators)...,))
+end
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum) # defined to avoid method ambiguity
+    LazySum(basis_l, basis_r, op.factors, ((embed(basis_l, basis_r, index, o) for o in op.operators)...,)) # dispatch to fast-path single-index `embed`
 end
 
 # Fast in-place multiplication

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -33,21 +33,21 @@ mutable struct LazyTensor{BL,BR,F,I,T} <: AbstractOperator{BL,BR}
         new{BL,BR,F_,I,T}(bl, br, factor_, indices, ops)
     end
 end
-function LazyTensor(bl::CompositeBasis, br::CompositeBasis, indices, ops::Vector, factor=_default_factor(ops))
+function LazyTensor(bl::CompositeBasis, br::CompositeBasis, indices::I, ops::Vector, factor::F=_default_factor(ops)) where {F,I}
     Base.depwarn("LazyTensor(bl, br, indices, ops::Vector, factor) is deprecated, use LazyTensor(bl, br, indices, Tuple(ops), factor) instead.",
                 :LazyTensor; force=true)
     return LazyTensor(bl,br,indices,Tuple(ops),factor)
 end
 
-function LazyTensor(basis_l::CompositeBasis, basis_r::Basis, indices::I, ops, factor::F=_default_factor(ops)) where {F,I}
+function LazyTensor(basis_l::CompositeBasis, basis_r::Basis, indices::I, ops::T, factor::F=_default_factor(ops)) where {F,I,T<:Tuple}
     br = CompositeBasis(basis_r.shape, [basis_r])
     return LazyTensor(basis_l, br, indices, ops, factor)
 end
-function LazyTensor(basis_l::Basis, basis_r::CompositeBasis, indices::I, ops, factor::F=_default_factor(ops)) where {F,I}
+function LazyTensor(basis_l::Basis, basis_r::CompositeBasis, indices::I, ops::T, factor::F=_default_factor(ops)) where {F,I,T<:Tuple}
     bl = CompositeBasis(basis_l.shape, [basis_l])
     return LazyTensor(bl, basis_r, indices, ops, factor)
 end
-function LazyTensor(basis_l::Basis, basis_r::Basis, indices::I, ops, factor::F=_default_factor(ops)) where {F,I}
+function LazyTensor(basis_l::Basis, basis_r::Basis, indices::I, ops::T, factor::F=_default_factor(ops)) where {F,I,T<:Tuple}
     bl = CompositeBasis(basis_l.shape, [basis_l])
     br = CompositeBasis(basis_r.shape, [basis_r])
     return LazyTensor(bl, br, indices, ops, factor)
@@ -338,14 +338,14 @@ function _tp_matmul_mid!(result::Base.ReshapedArray, a::AbstractMatrix, loc::Int
 
     @strided permutedims!(result_r, result_r_p, perm)
     #permutedims!(result_r, result_r_p, perm)
-    
+
     result
 end
 
 function _tp_matmul!(result, a::AbstractMatrix, loc::Integer, b, α::Number, β::Number)
     # Apply a matrix `α * a` to one tensor factor of a tensor `b`.
     # If β is nonzero, add to β times `result`. In other words, we do:
-    # result = α * a * b + β * result 
+    # result = α * a * b + β * result
     #
     # Parameters:
     #     result: Array to hold the output tensor.
@@ -491,7 +491,7 @@ function _explicit_isometries(used_indices, bl::Basis, br::Basis, shift=0)
     isos, iso_inds
 end
 
-# To get the shape of a CompositeBasis with number of dims inferrable at compile-time 
+# To get the shape of a CompositeBasis with number of dims inferrable at compile-time
 _comp_size(b::CompositeBasis) = tuple((length(b_) for b_ in b.bases)...)
 _comp_size(b::Basis) = (length(b),)
 

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -391,11 +391,11 @@ function _tp_sum_matmul!(result_data, tp_ops, iso_ops, b_data, alpha, beta)
         _tp_matmul!(result_data, first(ops)..., b_data, alpha, beta)
     elseif n_ops == 2
         # One temporary vector needed.
-        op1, istate = iterate(ops)
+        op1, istate = iterate(ops)::Tuple # "not-nothing" assertion to help type inference
         tmp = _tp_sum_get_tmp(op1..., b_data, :_tp_sum_matmul_tmp1)
         _tp_matmul!(tmp, op1..., b_data, alpha, zero(beta))
 
-        op2, istate = iterate(ops, istate)
+        op2, istate = iterate(ops, istate)::Tuple # "not-nothing" assertion to help type inference
         _tp_matmul!(result_data, op2..., tmp, one(alpha), beta)
     else
         # At least two temporary vectors needed.
@@ -403,18 +403,18 @@ function _tp_sum_matmul!(result_data, tp_ops, iso_ops, b_data, alpha, beta)
         sym1 = :_tp_sum_matmul_tmp1
         sym2 = :_tp_sum_matmul_tmp2
 
-        op1, istate = iterate(ops)
+        op1, istate = iterate(ops)::Tuple # "not-nothing" assertion to help type inference
         tmp1 = _tp_sum_get_tmp(op1..., b_data, sym1)
         _tp_matmul!(tmp1, op1..., b_data, alpha, zero(beta))
 
-        next = iterate(ops, istate)
+        next = iterate(ops, istate)::Tuple # "not-nothing" assertion to help type inference
         for _ in 2:n_ops-1
             op, istate = next
             tmp2 = _tp_sum_get_tmp(op..., tmp1, sym2)
             _tp_matmul!(tmp2, op..., tmp1, one(alpha), zero(beta))
             tmp1, tmp2 = tmp2, tmp1
             sym1, sym2 = sym2, sym1
-            next = iterate(ops, istate)
+            next = iterate(ops, istate)::Tuple # "not-nothing" assertion to help type inference
         end
 
         op, istate = next

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -165,16 +165,16 @@ function gemm!(alpha, B::AbstractMatrix, M::Adjoint{T,<:SparseMatrixCSC{T}}, bet
 end
 
 function gemm!(alpha, A::Adjoint{T, <:SparseMatrixCSC{T}}, B::Adjoint{S, <:SparseMatrixCSC{S}}, beta, result::AbstractMatrix) where {T,S}
-    throw(error("Matrix multiplication between Adjoint{SparseCSC} and SparseCSC matrices is not implemented yet. Submit an issue to the developers."))
+    error("Matrix multiplication between Adjoint{SparseCSC} and SparseCSC matrices is not implemented yet. Submit an issue to the developers.")
 end
 function gemm!(alpha, A::Adjoint{T, <:SparseMatrixCSC{T}}, B::SparseMatrixCSC, beta, result::AbstractMatrix) where T
-    throw(error("Matrix multiplication between Adjoint{SparseCSC} and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers."))
+    error("Matrix multiplication between Adjoint{SparseCSC} and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers.")
 end
 function gemm!(alpha, A::SparseMatrixCSC, B::Adjoint{T, <:SparseMatrixCSC{T}}, beta, result::AbstractMatrix) where T
-    throw(error("Matrix multiplication between SparseCSC and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers."))
+    error("Matrix multiplication between SparseCSC and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers.")
 end
 function gemm!(alpha, A::SparseMatrixCSC, B::SparseMatrixCSC, beta, result::AbstractMatrix)
-    throw(error("Matrix multiplication between SparseCSC and SparseCSC matrices is not implemented yet. Submit an issue to the developers."))
+    error("Matrix multiplication between SparseCSC and SparseCSC matrices is not implemented yet. Submit an issue to the developers.")
 end
 
 function gemv!(alpha, M::SparseMatrixCSC, v::AbstractVector, beta, result::AbstractVector)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -208,7 +208,7 @@ function gemv!(alpha, v::AbstractVector, M::SparseMatrixCSC, beta, result::Abstr
     end
 end
 
-function sub2sub(shape1, shape2, I) where {N, M}
+function sub2sub(shape1, shape2, I)
     linearindex = LinearIndices(shape1)[I.I...]
     CartesianIndices(shape2)[linearindex]
 end

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -164,6 +164,19 @@ function gemm!(alpha, B::AbstractMatrix, M::Adjoint{T,<:SparseMatrixCSC{T}}, bet
     gemm_dense_adj_sp(alpha, B, M.parent, result)
 end
 
+function gemm!(alpha, A::Adjoint{T, <:SparseMatrixCSC{T}}, B::Adjoint{S, <:SparseMatrixCSC{S}}, beta, result::AbstractMatrix) where {T,S}
+    throw(error("Matrix multiplication between Adjoint{SparseCSC} and SparseCSC matrices is not implemented yet. Submit an issue to the developers."))
+end
+function gemm!(alpha, A::Adjoint{T, <:SparseMatrixCSC{T}}, B::SparseMatrixCSC, beta, result::AbstractMatrix) where T
+    throw(error("Matrix multiplication between Adjoint{SparseCSC} and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers."))
+end
+function gemm!(alpha, A::SparseMatrixCSC, B::Adjoint{T, <:SparseMatrixCSC{T}}, beta, result::AbstractMatrix) where T
+    throw(error("Matrix multiplication between SparseCSC and Adjoint{SparseCSC} matrices is not implemented yet. Submit an issue to the developers."))
+end
+function gemm!(alpha, A::SparseMatrixCSC, B::SparseMatrixCSC, beta, result::AbstractMatrix)
+    throw(error("Matrix multiplication between SparseCSC and SparseCSC matrices is not implemented yet. Submit an issue to the developers."))
+end
+
 function gemv!(alpha, M::SparseMatrixCSC, v::AbstractVector, beta, result::AbstractVector)
     if iszero(beta)
         fill!(result, beta)

--- a/src/spinors.jl
+++ b/src/spinors.jl
@@ -39,6 +39,7 @@ function directsum(b1::SumBasis, b2::SumBasis)
     bases = [b1.bases...;b2.bases...]
     return SumBasis(shape, (bases...,))
 end
+directsum() = GenericBasis(0)
 
 const ⊕ = directsum
 

--- a/src/states.jl
+++ b/src/states.jl
@@ -253,10 +253,12 @@ function Broadcasted_restrict_f(f::BasicMathFunc, args::NTuple{N,<:T}, axes) whe
     args_ = Tuple(a.data for a=args)
     return Broadcast.Broadcasted(f, args_, axes)
 end
-function Broadcasted_restrict_f(f, args, axes)
+function Broadcasted_restrict_f(f, args::Tuple, axes)
     throw(error("Cannot broadcast function `$f` on $(typeof(args))"))
 end
-
+function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{}, axes) # Defined to avoid method ambiguities
+    throw(error("Cannot broadcast function `$f` on an empty set of arguments"))
+end
 
 # In-place broadcasting for Kets
 @inline function Base.copyto!(dest::Ket{B}, bc::Broadcast.Broadcasted{Style,Axes,F,Args}) where {B,Style<:KetStyle{B},Axes,F,Args}

--- a/src/states.jl
+++ b/src/states.jl
@@ -254,10 +254,10 @@ function Broadcasted_restrict_f(f::BasicMathFunc, args::NTuple{N,<:T}, axes) whe
     return Broadcast.Broadcasted(f, args_, axes)
 end
 function Broadcasted_restrict_f(f, args::Tuple, axes)
-    throw(error("Cannot broadcast function `$f` on $(typeof(args))"))
+    error("Cannot broadcast function `$f` on $(typeof(args))")
 end
 function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{}, axes) # Defined to avoid method ambiguities
-    throw(error("Cannot broadcast function `$f` on an empty set of arguments"))
+    error("Cannot broadcast function `$f` on an empty set of arguments")
 end
 
 # In-place broadcasting for Kets

--- a/src/states.jl
+++ b/src/states.jl
@@ -249,12 +249,12 @@ find_basis(a::StateVector, rest) = a.basis
 find_basis(::Any, rest) = find_basis(rest)
 
 const BasicMathFunc = Union{typeof(+),typeof(-),typeof(*)}
-function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{Vararg{<:T}}, axes) where T<:StateVector
+function Broadcasted_restrict_f(f::BasicMathFunc, args::NTuple{N,<:T}, axes) where {T<:StateVector,N}
     args_ = Tuple(a.data for a=args)
     return Broadcast.Broadcasted(f, args_, axes)
 end
-function Broadcasted_restrict_f(f, args::Tuple{Vararg{<:T}}, axes) where T<:StateVector
-    throw(error("Cannot broadcast function `$f` on type `$T`"))
+function Broadcasted_restrict_f(f, args, axes)
+    throw(error("Cannot broadcast function `$f` on $(typeof(args))"))
 end
 
 

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -242,9 +242,6 @@ function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{Vararg{<:SuperOper
     args_ = Tuple(a.data for a=args)
     return Broadcast.Broadcasted(f, args_, axes)
 end
-function Broadcasted_restrict_f(f, args::Tuple{Vararg{<:SuperOperator}}, axes)
-    throw(error("Cannot broadcast function `$f` on type `$(eltype(args))`"))
-end
 
 # In-place broadcasting
 @inline function Base.copyto!(dest::SuperOperator{BL,BR}, bc::Broadcast.Broadcasted{Style,Axes,F,Args}) where {BL,BR,Style<:SuperOperatorStyle{BL,BR},Axes,F,Args}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,10 @@ names = [
 
     "test_abstractdata.jl",
 
-    "test_printing.jl"
+    "test_printing.jl",
+
+    "test_aqua.jl",
+    "test_jet.jl"
 ]
 
 detected_tests = filter(

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,12 @@
+using Test
+using QuantumOpticsBase
+using Aqua
+
+@testset "aqua" begin
+    Aqua.test_all(QuantumOpticsBase,
+                  ambiguities=false,
+                  unbound_args=false, # TODO due to Aqua bug https://github.com/JuliaTesting/Aqua.jl/issues/87
+                  )
+    @test_broken false # fix the ambiguities test above
+    @test_broken false # fix the unbounds_args test above (it is an Aqua bug)
+end # testset

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -5,8 +5,6 @@ using Aqua
 @testset "aqua" begin
     Aqua.test_all(QuantumOpticsBase,
                   ambiguities=false,
-                  unbound_args=false, # TODO due to Aqua bug https://github.com/JuliaTesting/Aqua.jl/issues/87
                   )
     @test_broken false # fix the ambiguities test above
-    @test_broken false # fix the unbounds_args test above (it is an Aqua bug)
 end # testset

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -3,8 +3,5 @@ using QuantumOpticsBase
 using Aqua
 
 @testset "aqua" begin
-    Aqua.test_all(QuantumOpticsBase,
-                  ambiguities=false,
-                  )
-    @test_broken false # fix the ambiguities test above
+    Aqua.test_all(QuantumOpticsBase)
 end # testset

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -2,10 +2,37 @@ using Test
 using QuantumOpticsBase
 using JET
 
+using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport
+
+# Custom report pass that ignores `UncaughtExceptionReport`
+# Too coarse currently, but it serves to ignore the various
+# "may throw" messages for runtime errors we raise on purpose
+# (mostly on malformed user input)
+struct MayThrowIsOk <: ReportPass end
+
+# ignores `UncaughtExceptionReport` analyzed by `JETAnalyzer`
+(::MayThrowIsOk)(::Type{UncaughtExceptionReport}, @nospecialize(_...)) = return
+
+# forward to `BasicPass` for everything else
+function (::MayThrowIsOk)(report_type::Type{<:InferenceErrorReport}, @nospecialize(args...))
+    BasicPass()(report_type, args...)
+end
+
+# imported to be declared as modules filtered out from analysis result
+using LinearAlgebra, LRUCache, Strided, Dates, SparseArrays
+
 @testset "jet" begin
     if get(ENV,"QUANTUMOPTICS_JET_TEST","")=="true"
-        rep = report_package("QuantumOpticsBase"; ignored_modules=())
+        rep = report_package("QuantumOpticsBase";
+            report_pass=MayThrowIsOk(), # TODO have something more fine grained than a generic "do not care about thrown errors"
+            ignored_modules=( # TODO fix issues with these modules or report them upstrem
+                AnyFrameModule(LinearAlgebra),
+                AnyFrameModule(LRUCache),
+                AnyFrameModule(Strided),
+                AnyFrameModule(Dates),
+                AnyFrameModule(SparseArrays))
+            )
         @show rep
-        @test_broken length(JET.get_reports(rep)) == 0
+        @test length(JET.get_reports(rep)) == 0
     end
 end # testset

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -1,0 +1,11 @@
+using Test
+using QuantumOpticsBase
+using JET
+
+@testset "jet" begin
+    if get(ENV,"QUANTUMOPTICS_JET_TEST","")=="true"
+        rep = report_package("QuantumOpticsBase"; ignored_modules=())
+        @show rep
+        @test_broken length(JET.get_reports(rep)) == 0
+    end
+end # testset


### PR DESCRIPTION
Edit: this PR now completely integrates Aqua and JET static analysis in the test framework and fixes various (minor) issues detected by these tools.

~~This PR is not particularly useful on its own, but it makes it easier to start using Aqua and JET for static analysis. JET in particular is a great way to find bugs.~~

- [Aqua](https://github.com/JuliaTesting/Aqua.jl) is just for sanity checks. It did uncover a large number of method ambiguities, but some of them are unimportant. I have not tried to fix them for now and have just marked the test as broken.
- Aqua also complained about exporting symbols that are not actually defined. It seems they were used for documenting. I turned them into comments.
- JET found a ton of issues, but many of them are false positives. JET can be configured to skip these false positives, but that would take some more work. It seems there might be a couple of real issues in there too, but probably not worth investigating before filtering the false positives
- I added JET to a new CI run. It is not turned on by default because JET very frequently breaks on nightly which would lead to QuantumOpticsBase not being tracked by nanosoldier.

This can be merged without negative effects to the code base, but for it to actually be useful some more work needs to be done.