### PR TITLE
Reduce allocations for multipling LazyTensor of sparse and dense

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -394,7 +394,7 @@ multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_
 
 Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
 function Base.size(op::AbstractOperator, i::Int)
-    i < 1 && throw(ErrorException("dimension out of range, should be strictly positive, got $i"))
+    i < 1 && throw(ErrorException(lazy"dimension out of range, should be strictly positive, got $i"))
     i > 2 && return 1
     i==1 ? length(op.basis_l) : length(op.basis_r)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -394,7 +394,7 @@ multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_
 
 Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
 function Base.size(op::AbstractOperator, i::Int)
-    i < 1 && throw(ArgumentError("dimension out of range, should be strictly positive, got $i"))
+    i < 1 && throw(ErrorException("dimension out of range, should be strictly positive, got $i"))
     i > 2 && return 1
     i==1 ? length(op.basis_l) : length(op.basis_r)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -392,5 +392,9 @@ multiplicable(a::AbstractOperator, b::Ket) = multiplicable(a.basis_r, b.basis)
 multiplicable(a::Bra, b::AbstractOperator) = multiplicable(a.basis, b.basis_l)
 multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_r, b.basis_l)
 
-Base.size(op::AbstractOperator) = prod(length(op.basis_l),length(op.basis_r))
-Base.size(op::AbstractOperator, i::Int) = (i==1 ? length(op.basis_l) : length(op.basis_r))
+Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
+function Base.size(op::AbstractOperator, i::Int)
+    i < 1 && throw(ArgumentError("dimension out of range, should be strictly positive, got $i"))
+    i > 2 && return 1
+    i==1 ? length(op.basis_l) : length(op.basis_r)
+end

--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -274,6 +274,10 @@ function _strides(shape)
     return S
 end
 
+function _strides(shape::Ty)::Ty where Ty <: Tuple
+    accumulate(*, (1,Base.front(shape)...))
+end
+
 # Dense operator version
 @generated function _ptrace(::Type{Val{RANK}}, a,
                             shape_l, shape_r,

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -609,7 +609,7 @@ end
 function _gemm_recursive_lazy_dense(i_k, N_k, K, J, val,
                         shape, strides_k, strides_j,
                         indices, h::LazyTensor,
-                        op::Ts, result::Ts) where Ts<:Union{Vector,Matrix}
+                        op::VecOrMat, result::VecOrMat)
     if i_k > N_k
         for I=1:size(op, 2)
             result[J, I] += val*op[K, I]
@@ -652,7 +652,7 @@ function _gemm_puresparse(alpha, op::Matrix, h::LazyTensor{B1,B2,F,I,T}, beta, r
     _gemm_recursive_dense_lazy(1, N_k, 1, 1, alpha*h.factor, shape, strides_k, strides_j, h.indices, h, op, result)
 end
 
-function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::Ts, beta, result::Ts) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}},Ts<:Union{Vector,Matrix}}
+function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::VecOrMat, beta, result::VecOrMat) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
     if iszero(beta)
         fill!(result, beta)
     elseif !isone(beta)

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -572,9 +572,11 @@ end
 function _gemm_recursive_dense_lazy(i_k, N_k, K, J, val,
                         shape, strides_k, strides_j,
                         indices, h::LazyTensor,
-                        op::Matrix, result::Matrix)
+                        op::AbstractArray, result::AbstractArray)
     if i_k > N_k
-        for I=1:size(op, 1)
+        if isa(op, AbstractVector)
+            result[K] += val*op[J]
+        else I=1:size(op, 1)
             result[I, K] += val*op[I, J]
         end
         return nothing
@@ -609,7 +611,7 @@ end
 function _gemm_recursive_lazy_dense(i_k, N_k, K, J, val,
                         shape, strides_k, strides_j,
                         indices, h::LazyTensor,
-                        op::VecOrMat, result::VecOrMat)
+                        op::AbstractArray, result::AbstractArray)
     if i_k > N_k
         for I=1:size(op, 2)
             result[J, I] += val*op[K, I]
@@ -641,7 +643,7 @@ function _gemm_recursive_lazy_dense(i_k, N_k, K, J, val,
     end
 end
 
-function _gemm_puresparse(alpha, op::Matrix, h::LazyTensor{B1,B2,F,I,T}, beta, result::Matrix) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
+function _gemm_puresparse(alpha, op::AbstractArray, h::LazyTensor{B1,B2,F,I,T}, beta, result::AbstractArray) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
     if iszero(beta)
         fill!(result, beta)
     elseif !isone(beta)
@@ -652,7 +654,7 @@ function _gemm_puresparse(alpha, op::Matrix, h::LazyTensor{B1,B2,F,I,T}, beta, r
     _gemm_recursive_dense_lazy(1, N_k, 1, 1, alpha*h.factor, shape, strides_k, strides_j, h.indices, h, op, result)
 end
 
-function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::VecOrMat, beta, result::VecOrMat) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
+function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::AbstractArray, beta, result::AbstractArray) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
     if iszero(beta)
         fill!(result, beta)
     elseif !isone(beta)
@@ -673,10 +675,11 @@ end
 _mul_puresparse!(result::DenseOpType{B1,B3},h::LazyTensor{B1,B2,F,I,T},op::DenseOpType{B2,B3},alpha,beta) where {B1,B2,B3,F,I,T<:Tuple{Vararg{SparseOpPureType}}} = (_gemm_puresparse(alpha, h, op.data, beta, result.data); result)
 _mul_puresparse!(result::DenseOpType{B1,B3},op::DenseOpType{B1,B2},h::LazyTensor{B2,B3,F,I,T},alpha,beta) where {B1,B2,B3,F,I,T<:Tuple{Vararg{SparseOpPureType}}} = (_gemm_puresparse(alpha, op.data, h, beta, result.data); result)
 _mul_puresparse!(result::Ket{B1},a::LazyTensor{B1,B2,F,I,T},b::Ket{B2},alpha,beta) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}} = (_gemm_puresparse(alpha, a, b.data, beta, result.data); result)
+_mul_puresparse!(result::Bra{B2},a::Bra{B1},b::LazyTensor{B1,B2,F,I,T},alpha,beta) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}} = (_gemm_puresparse(alpha, a.data, b, beta, result.data); result)
 
-function _mul_puresparse!(result::Bra{B2},a::Bra{B1},b::LazyTensor{B1,B2,F,I,T},alpha,beta) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
-    a_data = reshape(a.data, 1, length(a.data))
-    result_data = reshape(result.data, 1, length(result.data))
-    _gemm_puresparse(alpha, a_data, b, beta, result_data)
-    result
-end
+#function _mul_puresparse!(result::Bra{B2},a::Bra{B1},b::LazyTensor{B1,B2,F,I,T},alpha,beta) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
+#    a_data = Base.ReshapedArray(a.data, (1, length(a.data)), ())
+#    result_data = Base.ReshapedArray(result.data, (1, length(result.data)), ())
+#    _gemm_puresparse(alpha, a_data, b, beta, result_data)
+#    result
+#end

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -664,10 +664,10 @@ function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::Matrix, beta, r
 end
 
 function _get_shape_and_srtides(h::LazyTensor{B1,B2,F,I,T}) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
-    shape = min.(_comp_size(h.basis_l), _comp_size(h.basis_r))
-    strides_j = _strides(_comp_size(h.basis_l))
-    strides_k = _strides(_comp_size(h.basis_r))
-    shape, strides_j, strides_k
+    shape_l, shape_r = _comp_size(h.basis_l), _comp_size(h.basis_r)
+    shape = min.(shape_l, shape_r)
+    strides_j, strides_k = _strides(shape_l), _strides(shape_r)
+    return shape, strides_j, strides_k
 end
 
 _mul_puresparse!(result::DenseOpType{B1,B3},h::LazyTensor{B1,B2,F,I,T},op::DenseOpType{B2,B3},alpha,beta) where {B1,B2,B3,F,I,T<:Tuple{Vararg{SparseOpPureType}}} = (_gemm_puresparse(alpha, h, op.data, beta, result.data); result)

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -663,7 +663,7 @@ function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::Matrix, beta, r
     _gemm_recursive_lazy_dense(1, N_k, 1, 1, alpha*h.factor, shape, strides_k, strides_j, h.indices, h, op, result)
 end
 
-function _get_shape_and_srtides(h::LazyTensor{B1,B2,F,I,T}) where {B1,B2,F,I,T<:Tuple{Vararg{SparseOpPureType}}}
+function _get_shape_and_srtides(h)
     shape_l, shape_r = _comp_size(h.basis_l), _comp_size(h.basis_r)
     shape = min.(shape_l, shape_r)
     strides_j, strides_k = _strides(shape_l), _strides(shape_r)

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -648,7 +648,7 @@ function _gemm_puresparse(alpha, op::Matrix, h::LazyTensor{B1,B2,F,I,T}, beta, r
         rmul!(result, beta)
     end
     N_k = length(h.basis_r.bases)
-    shape, strides_j, strides_k = _get_shape_and_srtides(h)
+    shape, strides_j, strides_k = _get_shape_and_strides(h)
     _gemm_recursive_dense_lazy(1, N_k, 1, 1, alpha*h.factor, shape, strides_k, strides_j, h.indices, h, op, result)
 end
 
@@ -659,11 +659,11 @@ function _gemm_puresparse(alpha, h::LazyTensor{B1,B2,F,I,T}, op::Matrix, beta, r
         rmul!(result, beta)
     end
     N_k = length(h.basis_l.bases)
-    shape, strides_j, strides_k = _get_shape_and_srtides(h)
+    shape, strides_j, strides_k = _get_shape_and_strides(h)
     _gemm_recursive_lazy_dense(1, N_k, 1, 1, alpha*h.factor, shape, strides_k, strides_j, h.indices, h, op, result)
 end
 
-function _get_shape_and_srtides(h)
+function _get_shape_and_strides(h)
     shape_l, shape_r = _comp_size(h.basis_l), _comp_size(h.basis_r)
     shape = min.(shape_l, shape_r)
     strides_j, strides_k = _strides(shape_l), _strides(shape_r)

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -130,4 +130,14 @@ op12 = destroy(bfock)⊗sigmap(bspin)
 @test embed(b, [1,2], op12) == destroy(bfock)⊗sigmap(bspin)⊗one(bspin)
 @test embed(b, [1,3], op12) == destroy(bfock)⊗one(bspin)⊗sigmap(bspin)
 
+# size of AbstractOperator
+b1, b2 = NLevelBasis.((2, 3))
+Lop1 = LazyTensor(b1^2, b2^2, 2, sparse(randoperator(b1, b2)))
+@test size(Lop1) == size(dense(Lop1)) == size(dense(Lop1).data)
+@test all(size(Lop1, k) == size(dense(Lop1), k) for k=1:4)
+@test_throws ErrorException size(Lop1,  0)
+@test_throws ErrorException size(Lop1, -1)
+@test_throws ErrorException size(dense(Lop1),  0) # check for consistency
+@test_throws ErrorException size(dense(Lop1), -1)
+
 end # testset

--- a/test/test_operators_lazytensor.jl
+++ b/test/test_operators_lazytensor.jl
@@ -404,5 +404,13 @@ dop = randoperator(b3a⊗b3b, b2a⊗b2b)
 @test dop*lop' ≈ Operator(dop.basis_l, lop.basis_l, dop.data*dense(lop).data')
 @test lop*dop' ≈ Operator(lop.basis_l, dop.basis_l, dense(lop).data*dop.data')
 
+# Dimension mismatches for LazyTensor with sparse
+b1, b2 = NLevelBasis.((2, 3))
+Lop1 = LazyTensor(b1^2, b2^2, 2, sparse(randoperator(b1, b2)))
+@test_throws DimensionMismatch Lop1*Lop1
+@test_throws DimensionMismatch dense(Lop1)*Lop1
+@test_throws DimensionMismatch sparse(Lop1)*Lop1
+@test_throws DimensionMismatch Lop1*dense(Lop1)
+@test_throws DimensionMismatch Lop1*sparse(Lop1)
 
 end # testset


### PR DESCRIPTION
Following suggestion from @amilsted regarding https://github.com/qojulia/QuantumOptics.jl/issues/352

`shape`, `strides_j` and `strides_k` in `_gemm_puresparse` function are implemented as `Tuple` to reduce allocations.