### PR TITLE
JET CI fixes

### DIFF
--- a/.github/workflows/ci-jet.yml
+++ b/.github/workflows/ci-jet.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          QUANTUMSAVORY_JET_TEST: true
+          QUANTUMOPTICS_JET_TEST: true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -215,7 +215,7 @@ function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
     start_indices_flat = [i[1] for i in indices]
     complement_indices_flat = Int[i for i=1:N if i ∉ indices_flat]
     operators_flat = AbstractOperator[]
-    if all([minimum(I):maximum(I);]==I for I in indices)
+    if all(([minimum(I):maximum(I);]==I)::Bool for I in indices) # type assertion to help type inference
         for i in 1:N
             if i in complement_indices_flat
                 push!(operators_flat, identityoperator(T, S, basis_l.bases[i], basis_r.bases[i]))

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -25,7 +25,7 @@ using LinearAlgebra, LRUCache, Strided, Dates, SparseArrays
     if get(ENV,"QUANTUMOPTICS_JET_TEST","")=="true"
         rep = report_package("QuantumOpticsBase";
             report_pass=MayThrowIsOk(), # TODO have something more fine grained than a generic "do not care about thrown errors"
-            ignored_modules=( # TODO fix issues with these modules or report them upstrem
+            ignored_modules=( # TODO fix issues with these modules or report them upstream
                 AnyFrameModule(LinearAlgebra),
                 AnyFrameModule(LRUCache),
                 AnyFrameModule(Strided),


### PR DESCRIPTION
To my surprise, the merge of JET as a static analyzer in the CI (a few months ago), actually squashed an incorrect debug flag that I was playing with locally. So... JET was not actually running in CI for quite a while. This enables the JET static analyzer once again.