### PR TITLE
Julia >=1.8 required since v0.3.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ LRUCache = "1"
 QuantumInterface = "0.1.0"
 Strided = "1"
 UnsafeArrays = "1"
-julia = "1.3"
+julia = "1.8"
 
 [extras]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
QuantumOpticsBase v0.3.10 makes use of the LazyString type, that has been introduced in Julia v1.8. For example, precompiling QuantumOpticsBase v0.3.10 on Julia v1.6.2 returns errors. This change increases the minimal Julia compatible version to v1.8.