### PR TITLE
Don't use lazy strings

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -394,7 +394,7 @@ multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_
 
 Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
 function Base.size(op::AbstractOperator, i::Int)
-    i < 1 && throw(ErrorException(lazy"dimension out of range, should be strictly positive, got $i"))
+    i < 1 && throw(ErrorException("dimension index is < 1"))
     i > 2 && return 1
     i==1 ? length(op.basis_l) : length(op.basis_r)
 end

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -654,15 +654,15 @@ end
 function _check_mul!_dim_compatibility(sizeR::Tuple, sizeA::Tuple, sizeB::Tuple)
     # R .= A*B
     if sizeA[2] != sizeB[1]
-        throw(DimensionMismatch(lazy"A has dimensions $sizeA but B has dimensions $sizeB. Can't do `A*B`"))
+        throw(DimensionMismatch("A and B dimensions do not match. Can't do `A*B`"))
     end
     if sizeR != (sizeA[1], Base.tail(sizeB)...) # using tail to account for vectors
-        throw(DimensionMismatch(lazy"R has dimensions $sizeR but A*B has dimensions $((sizeA[1], Base.tail(sizeB)...)). Can't do `R.=A*B`"))
+        throw(DimensionMismatch("Output dimensions do not match A*B. Can't do `R.=A*B`"))
     end
 end
 function _check_mul!_aliasing_compatibility(R, A, B)
     if R===A || R===B
-        throw(ArgumentError(lazy"output matrix must not be aliased with input matrix"))
+        throw(ArgumentError("output matrix must not be aliased with input matrix"))
     end
 end
 


### PR DESCRIPTION
Means we don't have to drop support for older Julia.