### PR TITLE
Fix bug in ptranspose and added corresponding tests

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -195,7 +195,7 @@ fidelity(rho::DenseOpType{B,B}, sigma::DenseOpType{B,B}) where {B} = tr(sqrt(sqr
 Partial transpose of rho with respect to subspace specified by indices,    
 where `indices` can be specified by a single integer, an array or a tuple of integers.
 """
-function ptranspose(rho::DenseOpType{B,B}, indices::Union{Vector{Int},Tuple{Vararg{Int}}}) where B<:CompositeBasis
+function ptranspose(rho::DenseOpType{B,B}, indices=1) where B<:CompositeBasis
     # adapted from qutip.partial_transpose (https://qutip.org/docs/4.0.2/modules/qutip/partial_transpose.html)
     # works as long as QuantumOptics.jl doesn't change the implementation of `tensor`, i.e. tensor(a,b).data = kron(b.data,a.data)
     nsys = length(rho.basis_l.shape)
@@ -210,11 +210,6 @@ function ptranspose(rho::DenseOpType{B,B}, indices::Union{Vector{Int},Tuple{Vara
     
 end
                         
-function ptranspose(rho::DenseOpType{B,B}, index::Int=1) where B<:CompositeBasis
-
-    return ptranspose(rho,[index])
-
-end
 
 
 """

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -192,8 +192,9 @@ fidelity(rho::DenseOpType{B,B}, sigma::DenseOpType{B,B}) where {B} = tr(sqrt(sqr
 """
     ptranspose(rho, indices)
 
-Partial transpose of rho with respect to subspace specified by indices,    
-where `indices` can be specified by a single integer, an array or a tuple of integers.
+Partial transpose of rho with respect to subsystem specified by indices. 
+                        
+The `indices` argument can be a single integer or a collection of integers.
 """
 function ptranspose(rho::DenseOpType{B,B}, indices=1) where B<:CompositeBasis
     # adapted from qutip.partial_transpose (https://qutip.org/docs/4.0.2/modules/qutip/partial_transpose.html)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -210,7 +210,7 @@ function ptranspose(rho::DenseOpType{B,B}, indices::Union{Vector{Int},Tuple{Vara
     
 end
                         
-function ptranspose(rho::DenseOpType{B,B}, index=1) where B<:CompositeBasis
+function ptranspose(rho::DenseOpType{B,B}, index::Int=1) where B<:CompositeBasis
 
     return ptranspose(rho,[index])
 

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -97,7 +97,12 @@ g = spindown(b1)
 psi3 = (e ⊗ g - g ⊗ e)/sqrt(2)
 
 rho = dm(psi3)  
-
+rho_pT1 = ptranspose(rho, 1)
+rho_pT1_an = 0.5*(dm(e ⊗ g) + dm(g ⊗ e) - (e ⊗ e) ⊗ dagger(g ⊗ g) - (g ⊗ g) ⊗ dagger(e ⊗ e))
+rho_pT2 = ptranspose(rho, 2)
+@test rho_pT1.data ≈ rho_pT1_an.data
+@test rho_pT2.data ≈ rho_pT1_an.data
+        
 @test_throws MethodError ptranspose(e ⊗ dagger(psi1))
 @test_throws MethodError ptranspose(dm(e))
 

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -78,10 +78,10 @@ b1 = SpinBasis(1//2)
 b2 = SpinBasis(1)
 b3 = FockBasis(3)
 
-# some tests for ptranspose only on randomly generated tripartite operators 
-# consisting of `nterm` linear combinations of seperable operators
+# some tests for ptranspose only, on randomly generated tripartite operators 
+# consisting of `nterm` linear combinations of simply seperable operators
 nterm = 3
-coefs = rand(3)
+coefs = rand(nterm)
 As = [DenseOperator(b1, rand(2,2)) for i = 1 : nterm]
 Bs = [DenseOperator(b2, rand(3,3)) for i = 1 : nterm]
 Cs = [DenseOperator(b3, rand(4,4)) for i = 1 : nterm]

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -73,16 +73,30 @@ rho = tensor(psi1, dagger(psi1))
 @test 1e-20 > abs2(fidelity(rho, sigma))
 
 # ptranspose
+  
+b1 = SpinBasis(1//2)
+b2 = SpinBasis(1)
+b3 = FockBasis(3)
+
+# some tests for ptranspose only on randomly generated tripartite operators 
+# consisting of `nterm` linear combinations of seperable operators
+nterm = 3
+coefs = rand(3)
+As = [DenseOperator(b1, rand(2,2)) for i = 1 : nterm]
+Bs = [DenseOperator(b2, rand(3,3)) for i = 1 : nterm]
+Cs = [DenseOperator(b3, rand(4,4)) for i = 1 : nterm]
+
+rho = sum([coefs[i]*As[i]⊗Bs[i]⊗Cs[i] for i = 1 : nterm]);
+
+@test ptranspose(rho,(1,3)) == sum([coefs[i]*transpose(As[i])⊗Bs[i]⊗transpose(Cs[i]) for i = 1 : nterm])
+@test ptranspose(rho,[2]) == transpose(ptranspose(rho,[1,3]))
+@test ptranspose(rho,1) == sum([coefs[i]*transpose(As[i])⊗Bs[i]⊗Cs[i] for i = 1 : nterm])
+  
 e = spinup(b1)
 g = spindown(b1)
 psi3 = (e ⊗ g - g ⊗ e)/sqrt(2)
 
-rho = dm(psi3)
-rho_pT1 = ptranspose(rho, 1)
-rho_pT1_an = 0.5*(dm(e ⊗ g) + dm(g ⊗ e) - (e ⊗ e) ⊗ dagger(g ⊗ g) - (g ⊗ g) ⊗ dagger(e ⊗ e))
-rho_pT2 = ptranspose(rho, 2)
-@test rho_pT1.data ≈ rho_pT1_an.data
-@test rho_pT2.data ≈ rho_pT1_an.data
+rho = dm(psi3)  
 
 @test_throws MethodError ptranspose(e ⊗ dagger(psi1))
 @test_throws MethodError ptranspose(dm(e))


### PR DESCRIPTION
fixed bug reported in #97 
the `ptranspose(rho::DenseOpType{B,B}, indices::Union{Vector{Int},Tuple{Vararg{Int}}})` method is added to support multi-index subsystems, and the original single-index method `ptranspose(rho::DenseOpType{B,B}, index::Int=1)` is kept for compatibility, but implemented as a special case using the multi-index version.
tests dedicated to the two methods are added.