### PR TITLE
Added multiplication of LazyOperators

### DIFF
--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -161,6 +161,15 @@ function *(a::DenseOpType{B1,B2}, b::LazyTensor{B2,B3}) where {B1,B2,B3}
     result
 end
 
+*(a::LazyTensor{B1,B2}, b::LazyProduct{B2,B3}) where {B1,B2,B3} = LazyProduct(a) * b
+*(a::LazyProduct{B1,B2}, b::LazyTensor{B2,B3}) where {B1,B2,B3} = a * LazyProduct(b)
+
+#*(a::LazyTensor{B1,B2}, b::AbstractOperator{B2,B3}) where {B1,B2,B3} = LazyProduct((a, b), 1)
+#*(a::AbstractOperator{B1,B2}, b::LazyTensor{B2,B3}) where {B1,B2,B3} = LazyProduct((a, b), 1)
+#*(a::LazyTensor{B1,B2}, b::Operator{B2,B3}) where {B1,B2,B3} = LazyProduct((a, b), 1)
+#*(a::Operator{B1,B2}, b::LazyTensor{B2,B3}) where {B1,B2,B3} = LazyProduct((a, b), 1)
+
+
 /(a::LazyTensor, b::Number) = LazyTensor(a, a.factor/b)
 
 

--- a/test/test_operators_lazysum.jl
+++ b/test/test_operators_lazysum.jl
@@ -68,12 +68,15 @@ op1b = randoperator(b_l, b_r)
 op2a = randoperator(b_l, b_r)
 op2b = randoperator(b_l, b_r)
 op3a = randoperator(b_l, b_r)
+op4a = randoperator(b_r, b_l)
 op1 = LazySum([0.1, 0.3], (op1a, sparse(op1b)))
 op1_ = 0.1*op1a + 0.3*op1b
 op2 = LazySum([0.7, 0.9], [sparse(op2a), op2b])
 op2_ = 0.7*op2a + 0.9*op2b
 op3 = LazySum(op3a)
 op3_ = op3a
+op4 = LazySum(op4a)
+op4_ = op4a
 
 x1 = Ket(b_r, rand(ComplexF64, length(b_r)))
 x2 = Ket(b_r, rand(ComplexF64, length(b_r)))
@@ -94,13 +97,20 @@ xbra1 = Bra(b_l, rand(ComplexF64, length(b_l)))
 @test 1e-14 > D(op1 + (-1*op2), op1_ - op2_)
 
 # Test multiplication
-@test_throws ArgumentError op1*op2
+@test_throws DimensionMismatch op1*op2
 @test LazySum([0.1, 0.1], (op1a, op2a)) == LazySum(op1a, op2a)*0.1
 @test LazySum([0.1, 0.1], (op1a, op2a)) == 0.1*LazySum(op1a, op2a)
 @test 1e-11 > D(op1*(x1 + 0.3*x2), op1_*(x1 + 0.3*x2))
 @test 1e-11 > D(op1*x1 + 0.3*op1*x2, op1_*x1 + 0.3*op1_*x2)
 @test 1e-11 > D((op1+op2)*(x1+0.3*x2), (op1_+op2_)*(x1+0.3*x2))
 @test 1e-12 > D(dagger(x1)*dagger(0.3*op2), dagger(x1)*dagger(0.3*op2_))
+
+
+@test 1e-12 > D(op1*op4,op1_*op4_)
+@test 1e-12 > D(op4*op1,op4_*op1_)
+
+@test 1e-12 > D(LazyProduct(op1_)*op4,op1_*op4_)
+@test 1e-12 > D(op4*LazyProduct(op1_),op4_*op1_)
 
 ## Test multiplication with LazySum that has no elements
 @test iszero( LazySum(b_r, b_l) * op1a )

--- a/test/test_operators_lazytensor.jl
+++ b/test/test_operators_lazytensor.jl
@@ -105,6 +105,11 @@ op3_ = 0.3*I1 ⊗ I2 ⊗ subop3
 op4 = 0.4*LazyTensor(b_l, b_r, 2, subop2)
 op4_ = 0.4*I1 ⊗ subop2 ⊗ I3
 
+subop4 = randoperator(b2b, b2a)
+op5 = 0.3*LazyTensor(b_r, b_l, 2, subop4)
+op5_ = 0.3*identityoperator(b1b,b1a) ⊗ subop4 ⊗ identityoperator(b3b,b3a)
+
+
 x1 = Ket(b_r, rand(ComplexF64, length(b_r)))
 x2 = Ket(b_r, rand(ComplexF64, length(b_r)))
 xbra1 = Bra(b_l, rand(ComplexF64, length(b_l)))
@@ -157,6 +162,11 @@ op2_tensor_ =   op1_ ⊗ subop1
 @test 1e-12 > D(op1_*dagger(0.3*op2), op1_*dagger(0.3*op2_))
 @test 1e-12 > D(dagger(0.3*op2)*op1_, dagger(0.3*op2_)*op1_)
 @test 1e-12 > D(dagger(0.3*op2)*op1, dagger(0.3*op2_)*op1_)
+
+@test 1e-12 > D(op5*LazySum(op1_,op2_), op5_*(op1_+op2_))
+@test 1e-12 > D(LazySum(op1_,op2_)*op5, (op1_+op2_)*op5_)
+@test 1e-12 > D(op5*LazyProduct(op1_), op5_*op1_)
+@test 1e-12 > D(LazyProduct(op1_)*op5, op1_*op5_)
 
 
 # Test division


### PR DESCRIPTION
Added functions for multiplying two LazySum operators, LazySum with LazyTensor / LazyProduct and LazyTensor with LazyProduct. I also added tests for the new functions. 

Although debatable whether necessary, there might be situations where you would prefer not to explicitly have to calculate the product and create the appropriate LazyOperator. For example, if you wanted to create a unitary time evolution operator you might write:
```
U = identityoperator(H) - im*dt*H + (-im*dt)^2/2*H^2
```
where H is a LazyOperator. This is currently not possible, but with the few added lines of code here, you can do the above.


One thing to note is that when multiplying a non-lazy operator with a LazyOperator currently the following functions are used:
https://github.com/qojulia/QuantumOpticsBase.jl/blob/f98ec890036ca8de661d877a05471b6e2cfb2912/src/operators_dense.jl#L91-L110

The LazyOperators are thus not contagious with non-lazy operators in multiplication. This is, however, probably for the best since the above lines of code are also used when computing multiplication with a density matrix (which is represented as an operator) and in this instance, we don't want to create a LazyOperator but actually calculate e.g. the expectation value. If we wanted to have contagious LazyOperators in multiplication we would have to distinguish between operators and density matrices. 
