### PR TITLE
Use FastExpm.jl for matrix exponential of SparseSuperOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FastExpm = "7868e603-8603-432e-a1a1-694bd70b01f2"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,6 +18,7 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 [compat]
 Adapt = "1, 2, 3.3"
 FFTW = "1.2"
+FastExpm = "1.1.0"
 FillArrays = "0.13, 1"
 LRUCache = "1"
 QuantumInterface = "0.3.0"

--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -226,6 +226,12 @@ function expect(op::DataOperator{B1,B2}, state::DataOperator{B2,B2}) where {B1,B
     result
 end
 
+"""
+    exp(op::DenseOpType)
+
+Operator exponential used, for example, to calculate displacement operators.
+Uses LinearAlgebra's `Base.exp`.
+"""
 function exp(op::T) where {B,T<:DenseOpType{B,B}}
     return DenseOperator(op.basis_l, op.basis_r, exp(op.data))
 end

--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -231,6 +231,9 @@ end
 
 Operator exponential used, for example, to calculate displacement operators.
 Uses LinearAlgebra's `Base.exp`.
+
+If you only need the result of the exponential acting on a vector,
+consider using much faster implicit methods that do not calculate the entire exponential.
 """
 function exp(op::T) where {B,T<:DenseOpType{B,B}}
     return DenseOperator(op.basis_l, op.basis_r, exp(op.data))

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -53,6 +53,9 @@ Operator exponential used, for example, to calculate displacement operators.
 Uses [`FastExpm.jl.jl`](https://github.com/fmentink/FastExpm.jl) which will return a sparse
 or dense operator depending on which is more efficient.
 All optional arguments are passed to `fastExpm` and can be used to specify tolerances.
+
+If you only need the result of the exponential acting on a vector,
+consider using much faster implicit methods that do not calculate the entire exponential.
 """
 function exp(op::T; opts...) where {B,T<:SparseOpType{B,B}}
     return SparseOperator(op.basis_l, op.basis_r, fastExpm(op.data; opts...))

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -1,5 +1,6 @@
 import Base: ==, *, /, +, -, Broadcast
 import SparseArrays: sparse
+import FastExpm: fastExpm
 
 const SparseOpPureType{BL,BR} = Operator{BL,BR,<:SparseMatrixCSC}
 const SparseOpAdjType{BL,BR} = Operator{BL,BR,<:Adjoint{<:Number,<:SparseMatrixCSC}}
@@ -43,6 +44,18 @@ function expect(op::SparseOpPureType{B1,B2}, state::Operator{B2,B2}) where {B1,B
         end
     end
     result
+end
+
+"""
+    exp(op::SparseOpType; opts...)
+
+Operator exponential used, for example, to calculate displacement operators.
+Uses [`FastExpm.jl.jl`](https://github.com/fmentink/FastExpm.jl) which will return a sparse
+or dense operator depending on which is more efficient.
+All optional arguments are passed to `fastExpm` and can be used to specify tolerances.
+"""
+function exp(op::T; opts...) where {B,T<:SparseOpType{B,B}}
+    return SparseOperator(op.basis_l, op.basis_r, fastExpm(op.data; opts...))
 end
 
 function permutesystems(rho::SparseOpPureType{B1,B2}, perm) where {B1<:CompositeBasis,B2<:CompositeBasis}

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -1,4 +1,5 @@
 import QuantumInterface: AbstractSuperOperator
+import FastExpm: fastExpm
 
 """
     SuperOperator <: AbstractSuperOperator
@@ -221,9 +222,20 @@ end
 """
     exp(op::DenseSuperOperator)
 
-Operator exponential which can for example used to calculate time evolutions.
+Superoperator exponential which can, for example, be used to calculate time evolutions.
+Uses LinearAlgebra's `Base.exp`.
 """
 Base.exp(op::DenseSuperOpType) = DenseSuperOperator(op.basis_l, op.basis_r, exp(op.data))
+
+"""
+    exp(op::SparseSuperOperator; opts...)
+
+Superoperator exponential which can, for example, be used to calculate time evolutions.
+Uses [`FastExpm.jl.jl`](https://github.com/fmentink/FastExpm.jl) which will return a sparse
+or dense operator depending on which is more efficient.
+All optional arguments are passed to `fastExpm` and can be used to specify tolerances.
+"""
+Base.exp(op::SparseSuperOpType; opts...) = SuperOperator(op.basis_l, op.basis_r, fastExpm(op.data; opts...))
 
 # Array-like functions
 Base.size(A::SuperOperator) = size(A.data)

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -224,6 +224,9 @@ end
 
 Superoperator exponential which can, for example, be used to calculate time evolutions.
 Uses LinearAlgebra's `Base.exp`.
+
+If you only need the result of the exponential acting on an operator,
+consider using much faster implicit methods that do not calculate the entire exponential.
 """
 Base.exp(op::DenseSuperOpType) = DenseSuperOperator(op.basis_l, op.basis_r, exp(op.data))
 
@@ -234,6 +237,9 @@ Superoperator exponential which can, for example, be used to calculate time evol
 Uses [`FastExpm.jl.jl`](https://github.com/fmentink/FastExpm.jl) which will return a sparse
 or dense operator depending on which is more efficient.
 All optional arguments are passed to `fastExpm` and can be used to specify tolerances.
+
+If you only need the result of the exponential acting on an operator,
+consider using much faster implicit methods that do not calculate the entire exponential.
 """
 Base.exp(op::SparseSuperOpType; opts...) = SuperOperator(op.basis_l, op.basis_r, fastExpm(op.data; opts...))
 

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -114,7 +114,10 @@ OP_cnot = embed(b8, [1,3], op_cnot)
 @test reduced(OP_cnot, [1,3])/2. == op_cnot
 @test_throws AssertionError embed(b2⊗b2, [1,1], op_cnot)
 
-@test_throws ArgumentError exp(sparse(op1))
+b = FockBasis(40)
+alpha = 1+5im
+H = alpha * create(b) - conj(alpha) * destroy(b)
+@test exp(sparse(H); threshold=1e-10) ≈ displace(b, alpha)
 
 @test one(b1).data == Diagonal(ones(b1.shape[1]))
 @test one(op1).data == Diagonal(ones(b1.shape[1]))


### PR DESCRIPTION
I've found FastExpm to work quite well for creating the time evolution of certain, known to be sparse time evolution superoperators. For example

```julia
b = FockBasis(200)
L = liouvillian(identityoperator(b), [destroy(b)])
exp(L)
```

takes less then a second on my laptop. There's a relevant discussion here https://github.com/JuliaLang/julia/issues/32899 about upstream julia not wanting to implement sparse matrix exponential. However I think it makes sense to rely on FastExpm here since my guess is that most typcial Lindbladians can be computed efficiently by it.