### PR TITLE
Create ChoiState type and conversions to/from SuperOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -36,8 +36,8 @@ export Basis, GenericBasis, CompositeBasis, basis,
                 current_time, time_shift, time_stretch, time_restrict, static_operator,
         #superoperators
                 SuperOperator, DenseSuperOperator, DenseSuperOpType,
-                SparseSuperOperator, SparseSuperOpType, spre, spost, sprepost, liouvillian,
-                identitysuperoperator,
+                SparseSuperOperator, SparseSuperOpType, ChoiState, 
+                spre, spost, sprepost, liouvillian, identitysuperoperator,
         #fock
                 FockBasis, number, destroy, create,
                 fockstate, coherentstate, coherentstate!,

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -36,8 +36,8 @@ export Basis, GenericBasis, CompositeBasis, basis,
                 current_time, time_shift, time_stretch, time_restrict, static_operator,
         #superoperators
                 SuperOperator, DenseSuperOperator, DenseSuperOpType,
-                SparseSuperOperator, SparseSuperOpType, ChoiState, 
-                spre, spost, sprepost, liouvillian, identitysuperoperator,
+                SparseSuperOperator, SparseSuperOpType, spre, spost, sprepost, liouvillian,
+                identitysuperoperator,
         #fock
                 FockBasis, number, destroy, create,
                 fockstate, coherentstate, coherentstate!,

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -336,7 +336,6 @@ mutable struct ChoiState{B1,B2,T} <: AbstractSuperOperator{B1,B2}
         new(basis_l, basis_r, data)
     end
 end
-ChoiState{BL,BR}(b1::BL, b2::BR, data::T) where {BL,BR,T} = ChoiState{BL,BR,T}(b1, b2, data)
 ChoiState(b1::BL, b2::BR, data::T) where {BL,BR,T} = ChoiState{BL,BR,T}(b1, b2, data)
 
 dense(a::ChoiState) = ChoiState(a.basis_l, a.basis_r, Matrix(a.data))

--- a/test/test_superoperators.jl
+++ b/test/test_superoperators.jl
@@ -1,6 +1,7 @@
 using Test
 using QuantumOpticsBase
 using SparseArrays, LinearAlgebra
+import QuantumOpticsBase: ChoiState # Remove when ChoiState is publicly exported
 
 @testset "superoperators" begin
 

--- a/test/test_time_dependent_operators.jl
+++ b/test/test_time_dependent_operators.jl
@@ -103,7 +103,7 @@ using LinearAlgebra, Random
     o_t_tup = TimeDependentSum(Tuple, o_t)
     @test QOB.static_operator(o_t_tup(t)).factors == [1.0im, t*3.0 + 0.0im]
     @test all(QOB.static_operator(o_t_tup(t)).operators .== (a, n))
-    @test (@allocated set_time!(o_t_tup, t)) == 0
+    @test_broken (@allocated set_time!(o_t_tup, t)) == 0
 
     o_t2 = TimeDependentSum(f1=>a, f2=>n)
     @test o_t(t) == o_t2(t)

--- a/test/test_time_dependent_operators.jl
+++ b/test/test_time_dependent_operators.jl
@@ -103,7 +103,11 @@ using LinearAlgebra, Random
     o_t_tup = TimeDependentSum(Tuple, o_t)
     @test QOB.static_operator(o_t_tup(t)).factors == [1.0im, t*3.0 + 0.0im]
     @test all(QOB.static_operator(o_t_tup(t)).operators .== (a, n))
-    @test_broken (@allocated set_time!(o_t_tup, t)) == 0
+    if VERSION.minor == 11 # issue #178 https://github.com/qojulia/QuantumOpticsBase.jl/issues/178
+        @test_broken (@allocated set_time!(o_t_tup, t)) == 0
+    else
+        @test (@allocated set_time!(o_t_tup, t)) == 0
+    end
 
     o_t2 = TimeDependentSum(f1=>a, f2=>n)
     @test o_t(t) == o_t2(t)


### PR DESCRIPTION
Unlike qutip, which uses `type = super, superrep = choi` to mark a `qobj` as a superoperator in the choi representation, I personally think it makes more sense to just reuse the normal `Operator` type to represent a choi matrix since it must be a valid density operator after all. Also it often makes sense to compute things like the Von Neumann entropy of the choi state. To convert back to the superoperator representation, one needs to assume some convention for which of the two Hilbert spaces is the auxiliary/reference/environment system and which represents the channel's output system. I've chosen the convention which seems standard to have the first system be the reference and the second be the output system.

I still need to add docs and tests but I thought I'd open this now as a draft so that there can be some discussion of these choices. Also this might be a good time to follow through on the TODO to upstream `_permutedims` and maybe figure out how to make it operate on `ReshapedSparseArray`?

### Rough TODO list:

- [x] converters back and forth between the 3 types
- [x] docstrings with doctest-based examples
- [x] test for correctness
- [x] application methods (e.g. at the very least having multiplication operator between superoperators and density matrices)