### PR TITLE
[WIP] Improve generation performance in manybody.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Performance optimizations:
- Setting an sparse matrix like `mat[i, j] = k` is extremely slow and unoptimal when done in a loop. It can be avoided by creating three separate lists for values and indices and calling `sparse(is, js, vs, size1, size2)` in the end.
- Allocating new arrays or copying existing ones causes significant slowdown. The new `coefficient` function does not allocate new arrays (or copy old ones) and accepts any iterable as indices - even single number values (they are iterable, too!).

Combined together this yields a 300x performance boost (23s -> 75ms for a full boson basis with 2 particles on 36 modes) for the `manybodyoperator` function.

Still, this is nearly not enough for large systems (for example, when there are 3 particles, `manybodypoerator` runs for 12 seconds), so we have to do something better. My simplest proposal is making the occupations vectors sparse to make finding the coefficients easier, but probably there is an even better idea somewhere.