### PR TITLE
Fix displace_analytical when alpha is an integer type

### DIFF
--- a/src/fock.jl
+++ b/src/fock.jl
@@ -100,8 +100,9 @@ function displace_analytical(alpha::Number, n::Integer, m::Integer)
     if n < m
         return (-1)^isodd(abs(n - m)) * conj(displace_analytical(alpha, m, n))
     end
+    alpha = float(alpha) # promote alpha to float
     # compute factorial ratio directly, in float representation, to avoid integer overflow
-    s = 1.0 * one(real(alpha))
+    s = float(one(real(alpha)))
     for i in (m + 1):n
         s *= i
     end

--- a/test/test_fock.jl
+++ b/test/test_fock.jl
@@ -50,6 +50,8 @@ d = displace(b, alpha)
 @test 1e-12 > D(dagger(d)*d, identityoperator(b))
 @test 1e-12 > D(dagger(d), displace(b, -alpha))
 @test 1e-15 > norm(coherentstate(b, alpha) - displace(b, alpha)*fockstate(b, 0))
+alpha = 5
+@test coherentstate(b, alpha) ≈ displace_analytical(b, alpha)*fockstate(b, 0)
 
 # Test squeezing operator
 b = FockBasis(30)


### PR DESCRIPTION
I recently got bitten by this subtle bug caused when naively calling `displace_analytical(FockBasis(30), 5)` which then causes `alpha^(n - m)` to overflow for `n-m>27` since it's calculated as `Int64`. I think given how easy it is to overflow for even smallish displacements, we should ensure displace_analytical always computes using floating point.