### PR TITLE
Make `apply!` work when used with any order of subsystem indices

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -31,6 +31,9 @@ function apply!(state::Ket, indices, operation::T) where {T<:AbstractSuperOperat
 end
 
 function apply!(state::Operator, indices, operation::T) where {T<:AbstractSuperOperator}
+    if length(indices)>1
+        throw("Applying SuperOperator to multiple qubits/operators is not supported currently, due to missing tensor product method for SuperOperators")
+    end
     op = basis(state)==basis(operation) ? operation : embed(basis(state), indices, operation)
     state.data = (op*state).data
     state

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,5 +1,13 @@
 function apply!(state::Ket, indices, operation::Operator)
     op = basis(state)==basis(operation) ? operation : embed(basis(state), indices, operation)
+    if (length(indices)>1)
+        for i in 2:length(indices)
+            if indices[i]<indices[i-1]
+                op = permutesystems(op, indices)
+                break
+            end
+        end
+    end
     state.data = (op*state).data
     state
 end

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -14,6 +14,14 @@ end
 
 function apply!(state::Operator, indices, operation::Operator)
     op = basis(state)==basis(operation) ? operation : embed(basis(state), indices, operation)
+    if (length(indices)>1)
+        for i in 2:length(indices)
+            if indices[i]<indices[i-1]
+                op = permutesystems(op, indices)
+                break
+            end
+        end
+    end
     state.data = (op*state*op').data
     state
 end

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -32,7 +32,7 @@ end
 
 function apply!(state::Operator, indices, operation::T) where {T<:AbstractSuperOperator}
     if length(indices)>1
-        throw("Applying SuperOperator to multiple qubits/operators is not supported currently, due to missing tensor product method for SuperOperators")
+        error("Applying SuperOperator to multiple qubits/operators is not supported currently, due to missing tensor product method for SuperOperators")
     end
     op = basis(state)==basis(operation) ? operation : embed(basis(state), indices, operation)
     state.data = (op*state).data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,9 +36,10 @@ names = [
 
     "test_printing.jl",
 
+    "test_apply.jl",
+
     "test_aqua.jl",
-    "test_jet.jl",
-    "test_apply.jl"
+    "test_jet.jl"
 ]
 
 detected_tests = filter(

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -3,7 +3,7 @@ using QuantumInterface
 using Test
 
 @testset "apply" begin
-    
+
 _b2 = SpinBasis(1//2)
 _l0 = spinup(_b2)
 _l1 = spindown(_b2)
@@ -52,11 +52,11 @@ catch e
     #@test typeof(e) <: QuantumInterface.IncompatibleBases
 end
 
-#test CNOT₂₋₁
+# test CNOT₂₋₁
 CNOT = DenseOperator(_b2⊗_b2, Complex.([1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]))
 @test QuantumOpticsBase.apply!(_l0⊗_l1, [2,1], CNOT) == _l1⊗_l1
 
-#test operator permutation with 3 qubits/operators for apply!
+# test operator permutation with 3 qubits/operators for apply!
 
 # 3-qubit operator permutation
 @test QuantumOpticsBase.apply!(_l0⊗_l1⊗_l0, [2,3,1], _x⊗_y⊗_z) ≈ (_y*_l0)⊗(_z*_l1)⊗(_x*_l0)
@@ -64,13 +64,13 @@ CNOT = DenseOperator(_b2⊗_b2, Complex.([1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]))
 # 3-operator operator permutation
 @test QuantumOpticsBase.apply!(_x⊗_y⊗_z, [2,3,1], _x⊗_y⊗_z) ≈ (_y⊗_z⊗_x)*(_x⊗_y⊗_z)*(_y⊗_z⊗_x)'
 
-#3-qubit/operator errors when called for applying superoperator
+# 3-qubit/operator errors when called for applying superoperator
 sOp1 = spre(create(FockBasis(1)))
 sOp2 = spost(create(FockBasis(1)))
 st1 = coherentstate(FockBasis(1), 1.4)
 st2 = coherentstate(FockBasis(1), 0.3)
 st3 = coherentstate(FockBasis(1), 0.8)
 
-@test_throws "Applying SuperOperator to multiple qubits/operators is not supported currently, due to missing tensor product method for SuperOperators" QuantumOpticsBase.apply!(st1⊗st2⊗st3, [2,3,1], sOp1)
+@test_throws ErrorException QuantumOpticsBase.apply!(st1⊗st2⊗st3, [2,3,1], sOp1)
 
 end #testset

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -52,4 +52,8 @@ catch e
     #@test typeof(e) <: QuantumInterface.IncompatibleBases
 end
 
+#test CNOT₂₋₁
+CNOT = DenseOperator(_b2⊗_b2, Complex.([1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]))
+@test QuantumOpticsBase.apply!(_l0⊗_l1, [2,1], CNOT) == _l1⊗_l1
+
 end #testset

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -9,7 +9,7 @@ _l0 = spinup(_b2)
 _l1 = spindown(_b2)
 _x = sigmax(_b2)
 _y = sigmay(_b2)
-
+_z = sigmaz(_b2)
 
 @test QuantumOpticsBase.apply!(_l0⊗_l1, 1, _x) == _l1⊗_l1
 @test QuantumOpticsBase.apply!(_x, 1, _y) == _x
@@ -55,5 +55,13 @@ end
 #test CNOT₂₋₁
 CNOT = DenseOperator(_b2⊗_b2, Complex.([1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]))
 @test QuantumOpticsBase.apply!(_l0⊗_l1, [2,1], CNOT) == _l1⊗_l1
+
+#test operator permutation with 3 qubits/operators for apply!
+
+# 3-qubit operator permutation
+@test QuantumOpticsBase.apply!(_l0⊗_l1⊗_l0, [2,3,1], _x⊗_y⊗_z) ≈ (_y*_l0)⊗(_z*_l1)⊗(_x*_l0)
+
+# 3-operator operator permutation
+@test QuantumOpticsBase.apply!(_x⊗_y⊗_z, [2,3,1], _x⊗_y⊗_z) ≈ (_y⊗_z⊗_x)*(_x⊗_y⊗_z)*(_y⊗_z⊗_x)'
 
 end #testset

--- a/test/test_apply.jl
+++ b/test/test_apply.jl
@@ -64,4 +64,13 @@ CNOT = DenseOperator(_b2⊗_b2, Complex.([1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]))
 # 3-operator operator permutation
 @test QuantumOpticsBase.apply!(_x⊗_y⊗_z, [2,3,1], _x⊗_y⊗_z) ≈ (_y⊗_z⊗_x)*(_x⊗_y⊗_z)*(_y⊗_z⊗_x)'
 
+#3-qubit/operator errors when called for applying superoperator
+sOp1 = spre(create(FockBasis(1)))
+sOp2 = spost(create(FockBasis(1)))
+st1 = coherentstate(FockBasis(1), 1.4)
+st2 = coherentstate(FockBasis(1), 0.3)
+st3 = coherentstate(FockBasis(1), 0.8)
+
+@test_throws "Applying SuperOperator to multiple qubits/operators is not supported currently, due to missing tensor product method for SuperOperators" QuantumOpticsBase.apply!(st1⊗st2⊗st3, [2,3,1], sOp1)
+
 end #testset

--- a/test/test_time_dependent_operators.jl
+++ b/test/test_time_dependent_operators.jl
@@ -90,7 +90,7 @@ using LinearAlgebra, Random
 
     o_t1_comp2_ = embed(FockBasis(2) ⊗ GenericBasis(2), [1], o_t1)
     @test o_t1_comp2 == o_t1_comp2_
-    
+
     o_t = TimeDependentSum([f1, f2], [a,n])
     @test !QOB.is_const(o_t)
 
@@ -122,7 +122,7 @@ using LinearAlgebra, Random
 
     b = randoperator(FockBasis(2))
     o2_t = TimeDependentSum([t->cos(t), t->t/3.0], [b, n])
-    
+
     # operations
     o_res = o_t(0.0) + o2_t(0.0)
     @test isa(o_res, TimeDependentSum)
@@ -138,7 +138,7 @@ using LinearAlgebra, Random
     @test isa(o_res, TimeDependentSum)
     @test QOB.eval_coefficients(o_res, t) == [-1.0im, -t*3.0]
     @test all(QOB.suboperators(o_res) .== (a, n))
-    
+
     o_res = a + o2_t
     @test isa(o_res, TimeDependentSum)
     @test QOB.eval_coefficients(o_res, t) == ComplexF64[1.0, cos(t), t/3.0]
@@ -148,7 +148,7 @@ using LinearAlgebra, Random
     @test isa(o_res, TimeDependentSum)
     @test QOB.eval_coefficients(o_res, t) == ComplexF64[1.0, -cos(t), -t/3.0]
     @test all(QOB.suboperators(o_res) .== (a, b, n))
-    
+
     o_res = LazySum(a, n) + o2_t
     @test isa(o_res, TimeDependentSum)
     @test QOB.eval_coefficients(o_res, t) == ComplexF64[1.0, 1.0, cos(t), t/3.0]
@@ -221,7 +221,7 @@ end
     @test @inferred QOB.eval_coefficients(op_block_shift, 4.9) == (0.0, 0.0)
     @test @inferred QOB.eval_coefficients(op_block_shift, 5.0) == (1.0, -5.0)
     @test @inferred QOB.eval_coefficients(op_block_shift, 20.0) == (0.0, 0.0)
-    
+
     op_stretch_block_shift = time_stretch(op_block_shift, 2.0)
     @test @inferred QOB.eval_coefficients(op_stretch_block_shift, 9.9) == (0.0, 0.0)
     @test @inferred QOB.eval_coefficients(op_stretch_block_shift, 10.0) == (1.0, -5.0)


### PR DESCRIPTION
`apply!` needs to be able to permute the operator based on the order of the indices of the qubits/subsystems, e.g., doing CNOT<sub>2->1</sub>. Resolves QuantumSavory/QuantumSavory.jl/issues/39 cc @Krastanov 