### PR TITLE
Occupations interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.4.21"
+version = "0.4.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -54,7 +54,7 @@ export Basis, GenericBasis, CompositeBasis, basis,
         #nlevel
                 NLevelBasis, transition, nlevelstate,
         #manybody
-                ManyBodyBasis, fermionstates, bosonstates,
+                ManyBodyBasis, FermionBitstring, fermionstates, bosonstates,
                 manybodyoperator, onebodyexpect,
         #metrics
                 tracenorm, tracenorm_h, tracenorm_nh,

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -430,24 +430,6 @@ Base.@propagate_inbounds function state_transition!(buffer, occ::FermionBitstrin
     return 1
 end
 
-# This function exists merely for testing purposes
-function _vec2fb(occ::Vector{Int})
-    n = length(occ)
-    n > sizeof(UInt) * 8 && throw(ArgumentError("n must be less than $(sizeof(UInt) * 8)"))
-    bits = UInt(0)
-    for i in 1:n
-        if occ[i] != 0 && occ[i] != 1
-            throw(ArgumentError("Occupations must be 0 or 1"))
-        end
-        occ[i] == 1 && (bits |= UInt(1) << (i - 1))
-    end
-    FermionBitstring(bits, n)
-end
-function _vec2fb(mb::ManyBodyBasis)
-    new_sv = SortedVector(_vec2fb.(mb.occupations.sortedvector), mb.occupations.ord)
-    ManyBodyBasis(mb.onebodybasis, new_sv)
-end
-
 function _distribute_bosons(Nparticles, Nmodes, index, occupations, results)
     if index == Nmodes
         occupations[index] = Nparticles

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -360,6 +360,8 @@ Base.similar(occ::OccupationNumbers, ::Type{T}, dims::Dims) where {T} =
     OccupationNumbers(occ.statistics, similar(occ.occupations, T, dims))
 Base.similar(::Type{OccupationNumbers{StatisticsT,T}}, dims::Dims) where {StatisticsT,T} =
     OccupationNumbers(StatisticsT(), similar(Vector{T}, dims))
+Base.isless(occ1::OccupationNumbers, occ2::OccupationNumbers) = occ1.occupations < occ2.occupations
+Base.copyto!(dest::OccupationNumbers, src::OccupationNumbers) = copyto!(dest.occupations, src.occupations)
 Base.convert(::Type{OccupationNumbers{StatisticsT,T}}, occ::AbstractVector) where {StatisticsT,T} =
     OccupationNumbers(StatisticsT(), convert(Vector{T}, occ))
 
@@ -368,6 +370,7 @@ struct BosonStatistics end
 
 Base.@propagate_inbounds function state_transition!(buffer, occ::OccupationNumbers{BosonStatistics},
         at_indices, a_indices)
+    any(==(0), (occ[m] for m in a_indices)) && return nothing
     factor_sq = 1
     copyto!(buffer, occ)
     for i in a_indices
@@ -384,6 +387,7 @@ end
 
 Base.@propagate_inbounds function state_transition!(buffer, occ::OccupationNumbers{FermionStatistics},
         at_indices, a_indices)
+    any(==(0), (occ[m] for m in a_indices)) && return nothing
     factor = 1
     copyto!(buffer, occ)
     for i in a_indices

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -34,19 +34,11 @@ b = GenericBasis(Nmodes)
 @test ManyBodyBasis(b, bosonstates(b, 1)) == ManyBodyBasis(b, fermionstates(b, 1))
 @test ManyBodyBasis(b, bosonstates(b, 2)) != ManyBodyBasis(b, fermionstates(b, 2))
 
-function _vec2fb(occ::AbstractVector{Int})
-    n = length(occ)
-    n > sizeof(UInt) * 8 && throw(ArgumentError("n must be less than $(sizeof(UInt) * 8)"))
-    bits = UInt(0)
-    for i in 1:n
-        if occ[i] != 0 && occ[i] != 1
-            throw(ArgumentError("Occupations must be 0 or 1"))
-        end
-        occ[i] == 1 && (bits |= UInt(1) << (n - i))
-    end
-    FermionBitstring(bits, n)
-end
-@test collect(fermionstates(FermionBitstring, b, 3)) == _vec2fb.(fermionstates(b, 3))
+@test collect(fermionstates(FermionBitstring, b, 3)) ==
+    convert.(FermionBitstring, fermionstates(b, 3))
+b2 = GenericBasis(130)
+@test collect(fermionstates(FermionBitstring{BigInt}, b2, 2)) ==
+    convert.(FermionBitstring{BigInt}, fermionstates(b2, 2))
 
 # Test basisstate
 b_mb = ManyBodyBasis(b, bosonstates(b, 2))

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -34,7 +34,7 @@ b = GenericBasis(Nmodes)
 @test ManyBodyBasis(b, bosonstates(b, 1)) == ManyBodyBasis(b, fermionstates(b, 1))
 @test ManyBodyBasis(b, bosonstates(b, 2)) != ManyBodyBasis(b, fermionstates(b, 2))
 
-function _vec2fb(occ::Vector{Int})
+function _vec2fb(occ::AbstractVector{Int})
     n = length(occ)
     n > sizeof(UInt) * 8 && throw(ArgumentError("n must be less than $(sizeof(UInt) * 8)"))
     bits = UInt(0)

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -36,6 +36,8 @@ b = GenericBasis(Nmodes)
 
 @test collect(fermionstates(FermionBitstring, b, 3)) ==
     convert.(FermionBitstring, fermionstates(b, 3))
+@test collect(bosonstates(Vector{Int}, b, 3)) ==
+    convert.(Vector{Int}, bosonstates(b, 3))
 b2 = GenericBasis(130)
 @test collect(fermionstates(FermionBitstring{BigInt}, b2, 2)) ==
     convert.(FermionBitstring{BigInt}, fermionstates(b2, 2))

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -137,6 +137,30 @@ d3 = destroy(b_mb, 3)
 c2 = create(b_mb, 2)
 @test t22_33 ≈ c2 * c2 * d3 * d3
 
+# Test commutator and anticommutator
+state = basisstate(b_mb, [1, 0, 0, 0])
+a1 = destroy(b_mb, 1)
+at2 = create(b_mb, 2)
+at3 = create(b_mb, 3)
+@test 1e-12 > D(a1 * at2 * state, at2 * a1 * state)
+@test 1e-12 > D(at2 * at3 * state, at3 * at2 * state)
+
+f_mb = ManyBodyBasis(b, fermionstates(b, [0, 1, 2]))
+state = basisstate(f_mb, [1, 0, 0, 0])
+a1 = destroy(f_mb, 1)
+at2 = create(f_mb, 2)
+at3 = create(f_mb, 3)
+@test 1e-12 > D(a1 * at2 * state, -at2 * a1 * state)
+@test 1e-12 > D(at2 * at3 * state, -at3 * at2 * state)
+
+f_mb2 = ManyBodyBasis(b, fermionstates(FermionBitstring, b, [0, 1, 2]))
+state = basisstate(f_mb2, [1, 0, 0, 0])
+a1 = destroy(f_mb2, 1)
+at2 = create(f_mb2, 2)
+at3 = create(f_mb2, 3)
+@test 1e-12 > D(a1 * at2 * state, -at2 * a1 * state)
+@test 1e-12 > D(at2 * at3 * state, -at3 * at2 * state)
+
 # Single particle operator in second quantization
 b_single = GenericBasis(Nmodes)
 b = ManyBodyBasis(b_single, bosonstates(b_single, [1, 2]))


### PR DESCRIPTION
This PR extends #157 by providing a more thought-out occupations interface. It also fixes the #102 issue, because the statistics is now stored in the occupations object.

To implement the occupations interface, one must implement these methods for the object:
- Ordering by defining `==` and `isless`
- Conversion from the occupations represented as a `Vector{Int}`, aka `convert(::Type{YourType}, v::AbstractVector)` so that `basisstate` could work normally
- `QuantumOpticsBase.state_transition!(buffer, occ, at_inds, a_inds)` for transition coefficients
- `similar` (if mutable) or `QuantumOpticsBase.allocate_buffer` (if immutable) for allocating a buffer

Maybe this should be documented for someone who needs, for example, [anyon statistics](https://en.wikipedia.org/wiki/Anyon) or extra performance?