### PR TITLE
Export and document `static_operator`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -237,6 +237,10 @@ current_time
 ```
 
 ```@docs
+static_operator
+```
+
+```@docs
 set_time!
 ```
 

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -32,7 +32,7 @@ export Basis, GenericBasis, CompositeBasis, basis,
                 LazyKet,
         #time_dependent_operators
                 AbstractTimeDependentOperator, TimeDependentSum, set_time!,
-                current_time, time_shift, time_stretch, time_restrict,
+                current_time, time_shift, time_stretch, time_restrict, static_operator,
         #superoperators
                 SuperOperator, DenseSuperOperator, DenseSuperOpType,
                 SparseSuperOperator, SparseSuperOpType, spre, spost, sprepost, liouvillian,

--- a/src/time_dependent_operator.jl
+++ b/src/time_dependent_operator.jl
@@ -22,6 +22,17 @@ this throws an `ArgumentError`.
 """
 current_time(::T) where {T<:AbstractOperator} = 
   throw(ArgumentError("Time not defined for operators of type $T. Consider using a TimeDependentSum or another time-dependence wrapper."))
+
+"""
+    static_operator(op::AbstractOperator)
+
+Returns a static (not time dependent) representation of `op` the current time.
+This strips the time-dependence and can be used to obtain a non-lazy matrix
+representation of the operator.
+
+For example: `sparse(static_operator(op(t))` return a sparse-matrix representation
+of `op` at time `t`.
+"""
 static_operator(o::AbstractOperator) = o
 
 """


### PR DESCRIPTION
`static_operator()` is useful for getting a non-lazy matrix representation of a time-dependent operator, for example in order to diagonalize it at a time `t`.