### PR TITLE
Eliminate allocs in vector-based TimeDependentSums

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/time_dependent_operator.jl
+++ b/src/time_dependent_operator.jl
@@ -160,7 +160,14 @@ function set_time!(o::TimeDependentSum, t::Number)
         o.current_time = t
         update_static_coefficients!(static_operator(o), coefficients(o), t)
     end
-    set_time!.(suboperators(o), t)
+    subops = suboperators(o)
+    if subops isa Tuple
+        set_time!.(subops, t)
+    else
+        for so in subops
+            set_time!(so, t)
+        end
+    end
     o
 end
 


### PR DESCRIPTION
This is required to avoid allocs in set_time! with vector-backed TimeDependentSums.
Supports https://github.com/qojulia/QuantumOptics.jl/pull/401.