### PR TITLE
Remove unsafeviews from LazyTensors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumOpticsBase"
 uuid = "4f57444f-1401-5e15-980d-4471b28d5678"
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -282,11 +282,9 @@ function _tp_matmul_first!(result, a::AbstractMatrix, b, α::Number, β::Number)
     d_rest = length(b)÷d_first
     bp = parent(b)
     rp = parent(result)
-    @uviews bp rp begin  # avoid allocations on reshape
-        br = reshape(bp, (d_first, d_rest))
-        result_r = reshape(rp, (size(a, 1), d_rest))
-        mul!(result_r, a, br, α, β)
-    end
+    @views br = reshape(bp, (d_first, d_rest))
+    @views result_r = reshape(rp, (size(a, 1), d_rest))
+    mul!(result_r, a, br, α, β)
     result
 end
 
@@ -295,11 +293,9 @@ function _tp_matmul_last!(result, a::AbstractMatrix, b, α::Number, β::Number)
     d_rest = length(b)÷d_last
     bp = parent(b)
     rp = parent(result)
-    @uviews a bp rp begin  # avoid allocations on reshape
-        br = reshape(bp, (d_rest, d_last))
-        result_r = reshape(rp, (d_rest, size(a, 1)))
-        mul!(result_r, br, transpose(a), α, β)
-    end
+    @views br = reshape(bp, (d_rest, d_last))
+    @views result_r = reshape(rp, (d_rest, size(a, 1)))
+    mul!(result_r, br, transpose(a), α, β)
     result
 end
 


### PR DESCRIPTION
Currently, CUDA arrays cannot be used in lazy tensors due to unsafe views being used in the `mul!` implementation. This PR uses normal views instead, which after Julia 1.5 should be as performant as unsafeviews. Enabling Cuda arrays with LazyTensor could potentially help if the system is really huge and there is not enough memory to store the total matrix or allow for custom GPU kernels to be implemented (see [WaveguideQED.jl](https://github.com/qojulia/WaveguideQED.jl/tree/gpu) ). 

For a working minimal example where cuda arrays with LazyTensor ,see:

```julia


using QuantumOpticsBase
using CUDA

function to_gpu(a::Operator)
    data = cu(map(ComplexF32,a.data))
    gpu_operator = Operator(a.basis_l,a.basis_r,data)
    return gpu_operator
end

function to_gpu(a::Ket)
    data = cu(map(ComplexF32,a.data))
    gpu_operator = Ket(a.basis,data)
    return gpu_operator
end


bc = FockBasis(3)
a = destroy(bc)
b = destroy(bc)
bt = bc ⊗ bc



a_gpu = to_gpu((a))
b_gpu = to_gpu((b))

psi = Ket(bt)
psi.data .= 1
psi_temp = copy(psi)

psi_gpu = to_gpu(psi);
psi_temp_gpu = to_gpu(psi_temp);

LT_gpu = LazyTensor(bt, (1), (a_gpu))

QuantumOpticsBase.mul!(psi_temp_gpu, LT_gpu, psi_gpu);


```



Which gives the following error:

```julia

ERROR: MethodError: no method matching UnsafeArrays.UnsafeArray{ComplexF32, 1}(::Val{true}, ::CuPtr{ComplexF32}, ::Tuple{Int64})
The type `UnsafeArrays.UnsafeArray{ComplexF32, 1}` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  UnsafeArrays.UnsafeArray{T, N}(::Val{true}, ::Ptr{T}, ::NTuple{N, Int64}) where {T, N}
   @ UnsafeArrays C:\Users\mabun\.julia\packages\UnsafeArrays\xbma7\src\unsafe_array.jl:36
  UnsafeArrays.UnsafeArray{T, N}(::Ptr{T}, ::NTuple{N, Int64}) where {T, N}
   @ UnsafeArrays C:\Users\mabun\.julia\packages\UnsafeArrays\xbma7\src\unsafe_array.jl:42

Stacktrace:
 [1] _maybe_unsafe_uview
   @ C:\Users\mabun\.julia\packages\UnsafeArrays\xbma7\src\uview.jl:76 [inlined]
 [2] unsafe_uview
   @ C:\Users\mabun\.julia\packages\UnsafeArrays\xbma7\src\uview.jl:68 [inlined]
 [3] uview
   @ C:\Users\mabun\.julia\packages\UnsafeArrays\xbma7\src\uview.jl:30 [inlined]
 [4] _tp_matmul_first!(result::Base.ReshapedArray{…}, a::CUDA.CUSPARSE.CuSparseMatrixCSC{…}, b::Base.ReshapedArray{…}, α::ComplexF32, β::Bool)
   @ QuantumOpticsBase c:\Users\mabun\OneDrive - Danmarks Tekniske Universitet\Projects\WaveguideQED\scripts\QOTEST\QuantumOpticsBase.jl\src\operators_lazytensor.jl:285
 [5] _tp_matmul!(result::Base.ReshapedArray{…}, a::CUDA.CUSPARSE.CuSparseMatrixCSC{…}, loc::Int64, b::Base.ReshapedArray{…}, α::ComplexF32, β::Bool)
   @ QuantumOpticsBase c:\Users\mabun\OneDrive - Danmarks Tekniske Universitet\Projects\WaveguideQED\scripts\QOTEST\QuantumOpticsBase.jl\src\operators_lazytensor.jl:426
 [6] _tp_sum_matmul!(result_data::Base.ReshapedArray{…}, tp_ops::Tuple{…}, iso_ops::Nothing, b_data::Base.ReshapedArray{…}, alpha::ComplexF32, beta::Bool)
   @ QuantumOpticsBase c:\Users\mabun\OneDrive - Danmarks Tekniske Universitet\Projects\WaveguideQED\scripts\QOTEST\QuantumOpticsBase.jl\src\operators_lazytensor.jl:464
 [7] mul!(result::Ket{…}, a::LazyTensor{…}, b::Ket{…}, alpha::Bool, beta::Bool)
   @ QuantumOpticsBase c:\Users\mabun\OneDrive - Danmarks Tekniske Universitet\Projects\WaveguideQED\scripts\QOTEST\QuantumOpticsBase.jl\src\operators_lazytensor.jl:557
 [8] mul!(C::Ket{…}, A::LazyTensor{…}, B::Ket{…})
   @ LinearAlgebra C:\Users\mabun\.julia\juliaup\julia-1.11.1+0.x64.w64.mingw32\share\julia\stdlib\v1.11\LinearAlgebra\src\matmul.jl:253
 [9] top-level scope
   @ c:\Users\mabun\OneDrive - Danmarks Tekniske Universitet\Projects\WaveguideQED\scripts\QOTEST\src\gpu_test.jl:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Note that LazyProducts and LazySums also works with cuda arrays. For LazyProducts, one, however, needs to convert the ket_l and bra_r to cuda arrays like so:

```julia


function to_gpu(a::Bra)
    data = cu(map(ComplexF32,a.data))
    gpu_operator = Bra(a.basis,data)
    return gpu_operator
end
function to_gpu(a::LazyProduct)
    ops = [to_gpu(op) for op in a.operators]
    ket_ls  = Tuple(to_gpu(ket) for ket in a.ket_l)
    bra_rs = Tuple(to_gpu(bra) for bra in a.bra_r)
    KTL = typeof(ket_ls)
    BTR = typeof(bra_rs)
    BL = typeof(a.basis_l)
    BR = typeof(a.basis_r)
    F = typeof(a.factor)
    T = typeof(ops)
    LazyProduct{BL,BR,F,T,KTL,BTR}(ops,ket_ls,bra_rs,a.factor)
end

LP = LazyProduct(a ⊗ identityoperator(bc),b⊗ identityoperator(bc))
LP_gpu = to_gpu(LP)
QuantumOpticsBase.mul!(psi_temp_gpu, LP_gpu, psi_gpu); #works

```
