### PR TITLE
Fix printing of `SparseOpPureType`

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -91,7 +91,8 @@ function show(stream::IO, x::SparseOpPureType)
             if !haskey(stream, :compact) && (VERSION < v"1.6.0-beta1")
                 stream = IOContext(stream, :compact => true)
             end
-            show(stream, round.(x.data; digits=machineprecorder))
+            print(stream, "\n")
+            Base.print_array(stream, round.(x.data; digits=machineprecorder))
         else
             showsparsearray_stdord(stream, round.(x.data; digits=machineprecorder), x.basis_l.shape, x.basis_r.shape)
         end


### PR DESCRIPTION
See #45.

```
julia> create(FockBasis(2)) # before
Operator(dim=3x3)
  basis: Fock(cutoff=2)sparse([2, 3], [1, 2], ComplexF64[1.0 + 0.0im, 1.4142135623730951 + 0.0im], 3, 3)

julia> create(FockBasis(2)) # after
Operator(dim=3x3)
  basis: Fock(cutoff=2)
      ⋅                           ⋅            ⋅     
 1.0 + 0.0im                      ⋅            ⋅     
      ⋅       1.4142135623730951 + 0.0im       ⋅    

julia> QuantumOpticsBase.set_printing(standard_order = true)

julia> create(FockBasis(2))
Operator(dim=3x3)
  basis: Fock(cutoff=2)
  [2, 1]  =  1.0+0.0im
  [3, 2]  =  1.41421+0.0im
```