### PR TITLE
Remove `_permutedims` in favor of `Base.PermutedDimsArray`

### DIFF
--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -245,10 +245,10 @@ end
 function permutesystems(a::Operator{B1,B2}, perm) where {B1<:CompositeBasis,B2<:CompositeBasis}
     @assert length(a.basis_l.bases) == length(a.basis_r.bases) == length(perm)
     @assert isperm(perm)
-    data = reshape(a.data, [a.basis_l.shape; a.basis_r.shape]...)
-    data = permutedims(data, [perm; perm .+ length(perm)])
-    data = reshape(data, length(a.basis_l), length(a.basis_r))
-    return Operator(permutesystems(a.basis_l, perm), permutesystems(a.basis_r, perm), data)
+    data = Base.ReshapedArray(a.data, (a.basis_l.shape..., a.basis_r.shape...), ())
+    data = PermutedDimsArray(data, [perm; perm .+ length(perm)])
+    data = Base.ReshapedArray(data, (length(a.basis_l), length(a.basis_r)), ())
+    return Operator(permutesystems(a.basis_l, perm), permutesystems(a.basis_r, perm), copy(data))
 end
 permutesystems(a::AdjointOperator{B1,B2}, perm) where {B1<:CompositeBasis,B2<:CompositeBasis} = dagger(permutesystems(dagger(a),perm))
 

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -63,14 +63,6 @@ function exp(op::T; opts...) where {B,T<:SparseOpType{B,B}}
     end
 end
 
-function permutesystems(rho::SparseOpPureType{B1,B2}, perm) where {B1<:CompositeBasis,B2<:CompositeBasis}
-    @assert length(rho.basis_l.bases) == length(rho.basis_r.bases) == length(perm)
-    @assert isperm(perm)
-    shape = [rho.basis_l.shape; rho.basis_r.shape]
-    data = _permutedims(rho.data, shape, [perm; perm .+ length(perm)])
-    SparseOperator(permutesystems(rho.basis_l, perm), permutesystems(rho.basis_r, perm), data)
-end
-
 identityoperator(::Type{T}, ::Type{S}, b1::Basis, b2::Basis) where {T<:SparseOpType,S<:Number} =
     SparseOperator(b1, b2, sparse(one(S)*I, length(b1), length(b2)))
 identityoperator(::Type{T}, ::Type{S}, b::Basis) where {T<:SparseOpType,S<:Number} =

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1,5 +1,3 @@
-import Base: permutedims
-
 function gemm_sp_dense_small(alpha, M::SparseMatrixCSC, B::AbstractMatrix, result::AbstractMatrix)
     if isone(alpha)
         @inbounds for colindex = 1:M.n
@@ -237,22 +235,4 @@ function gemv!(alpha, v::AbstractVector, M::SparseMatrixCSC, beta, result::Abstr
             end
         end
     end
-end
-
-
-
-
-function _permutedims(x::AbstractSparseMatrix, shape, perm) # TODO upstream as `permutedims` to SparseArrays to avoid piracy -- used in a single location in operators_sparse
-    shape = (shape...,)
-    shape_perm = ([shape[i] for i in perm]...,)
-    y = spzeros(eltype(x), x.m, x.n)
-    for I in eachindex(x)::CartesianIndices # Help with inference (detected by JET)
-        linear_index = LinearIndices((x.m, x.n))[I.I...]
-        cartesian_index = CartesianIndices(shape)[linear_index]
-        cartesian_index_perm = [cartesian_index[i] for i=perm]
-        linear_index_perm = LinearIndices(shape_perm)[cartesian_index_perm...]
-        J = Tuple(CartesianIndices((x.m, x.n))[linear_index_perm])
-        y[J...] = x[I.I...]
-    end
-    y
 end


### PR DESCRIPTION
The following microbenchmarks show that using `Base.PermutedDimsArray` over `_permutedims` gives an over 50x speedup for sparse arrays while still retaining the same performance for dense arrays. This means that the two separate implementations of `permutesystems` can be unified into one function.

```julia
using BenchmarkTools
using SparseArrays

function _permutedims(x::AbstractSparseMatrix, shape, perm)
    shape = (shape...,)
    shape_perm = ([shape[i] for i in perm]...,)
    y = spzeros(eltype(x), x.m, x.n)
    for I in eachindex(x)::CartesianIndices # Help with inference (detected by JET)
        linear_index = LinearIndices((x.m, x.n))[I.I...]
        cartesian_index = CartesianIndices(shape)[linear_index]
        cartesian_index_perm = [cartesian_index[i] for i=perm]
        linear_index_perm = LinearIndices(shape_perm)[cartesian_index_perm...]
        J = Tuple(CartesianIndices((x.m, x.n))[linear_index_perm])
        y[J...] = x[I.I...]
    end
    y
end

function permute1(A,N)
    A = Base.ReshapedArray(A, (N,N,N,N), ())
    A = PermutedDimsArray(A, (1,3,2,4))
    A = Base.ReshapedArray(A, (N^2, N^2), ())
    copy(A)
end

permute2(A,N) = _permutedims(A, (N,N,N,N), (1,3,2,4))

function permute3(A,N)
    A = reshape(A, (N,N,N,N))
    A = permutedims(A, (1,3,2,4))
    A = reshape(A, (N^2, N^2))
    copy(A)
end

N = 10; D = 0.1
A = sprand(ComplexF64, N^2, N^2, D)
B = Matrix(A)
```

```julia
julia> @benchmark permute1(A,N)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  174.834 μs …  1.297 ms  ┊ GC (min … max): 0.00% … 84.53%
 Time  (median):     178.875 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   183.247 μs ± 23.841 μs  ┊ GC (mean ± σ):  1.12% ±  4.82%

  ██▇▇▆▄▄▃▂▂▃▂▁  ▁                                             ▂
  ██████████████████▇▇█▇▆▅▅▅▆▆▅▄▄▄▄▁▃▃▄▁▁▁▁▁▁▁▁▃▁▁▁▁▁▃▅▅▅▅▇▇▆▅ █
  175 μs        Histogram: log(frequency) by time       286 μs <

 Memory estimate: 106.69 KiB, allocs estimate: 22.

julia> @benchmark permute2(A,N)
BenchmarkTools.Trial: 487 samples with 1 evaluation per sample.
 Range (min … max):   9.646 ms …  14.207 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):      9.910 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.270 ms ± 759.861 μs  ┊ GC (mean ± σ):  3.72% ± 6.10%

      ▃▆█▁                                                      
  ▇█▆▆████▇▄▃▃▃▁▂▁▂▂▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▃▃▄▄▄▅▄▄▃▄▂▂▂▂▂▁▂▁▁▂ ▃
  9.65 ms         Histogram: frequency by time         12.1 ms <

 Memory estimate: 7.53 MiB, allocs estimate: 199005.

julia> @benchmark permute1(B,N)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  19.709 μs …   8.364 ms  ┊ GC (min … max):  0.00% … 99.03%
 Time  (median):     26.750 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   33.435 μs ± 135.565 μs  ┊ GC (mean ± σ):  16.57% ±  8.36%

  ▆ █▅▃▂▂▁                                                     ▁
  █████████▆▆▅▆▅▅▃▁▄▃▄▄▄▄▃▃▃▁▃▁▁▃▃▃▃▃▃▁▁▃▁▄▁▄▃▃▁▁▄▁▃▁▃▁▁▁▁▁▃▃▃ █
  19.7 μs       Histogram: log(frequency) by time       204 μs <

 Memory estimate: 160.36 KiB, allocs estimate: 9.

julia> @benchmark permute3(B,N)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  11.000 μs …  5.122 ms  ┊ GC (min … max):  0.00% … 99.02%
 Time  (median):     23.541 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   30.585 μs ± 91.772 μs  ┊ GC (mean ± σ):  25.28% ± 11.85%

  ▁ ██                                                         
  █▃██▃▃▂▂▂▂▂▁▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂ ▂
  11 μs           Histogram: frequency by time         276 μs <

 Memory estimate: 320.23 KiB, allocs estimate: 7.
```