### PR TITLE
Add broadcasting support for `obj .= scalar`

### DIFF
--- a/test/test_operators_dense.jl
+++ b/test/test_operators_dense.jl
@@ -382,6 +382,8 @@ op1 .= op1_ .+ 3 * op1_
 bf = FockBasis(3)
 op3 = randoperator(bf)
 @test_throws QuantumOpticsBase.IncompatibleBases op1 .+ op3
+op .= 1.0
+@test op == fill!(zero(op), 1.0)
 
 # Dimension mismatches
 b1, b2, b3 = NLevelBasis.((2,3,4))  # N is not a type parameter

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -166,6 +166,10 @@ psi_ .+= psi123
 bra_ = copy(bra123)
 bra_ .= 3*bra123
 @test bra_ == 3*dagger(psi123)
+bra .= 1.0
+ket .= 1.0
+@test bra == Bra(bf, [1.0 + 0.0im, 1.0 + 0.0im])
+@test ket == Ket(bf, [1.0 + 0.0im, 1.0 + 0.0im])
 
 end # testset
 


### PR DESCRIPTION
Helps with future work down the line for supporting autodiff capabilities.  Here's a resulting example of this PR implementation:
```
julia> state = randstate(GenericBasis(3)); state .= 1.0
Ket(dim=3)
  basis: Basis(dim=3)
 1.0 + 0.0im
 1.0 + 0.0im
 1.0 + 0.0im
```