### PR TITLE
Add embed_lazy for lazy operator embedding

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -221,6 +221,10 @@ embed
 ```
 
 ```@docs
+embed_lazy
+```
+
+```@docs
 permutesystems
 ```
 

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -20,7 +20,7 @@ export Basis, GenericBasis, CompositeBasis, basis,
                 dagger, normalize, normalize!,
         #operators
                 AbstractOperator, DataOperator, expect, variance,
-                identityoperator, ptrace, reduced, embed, dense, tr, sparse,
+                identityoperator, ptrace, reduced, embed, embed_lazy, dense, tr, sparse,
         #operators_dense
                 Operator, DenseOperator, DenseOpType, projector, dm,
         #operators_sparse
@@ -88,6 +88,7 @@ include("operators_lazysum.jl")
 include("operators_lazyproduct.jl")
 include("operators_lazytensor.jl")
 include("time_dependent_operator.jl")
+include("embed_lazy.jl")
 include("states_lazyket.jl")
 include("superoperators.jl")
 include("spin.jl")

--- a/src/embed_lazy.jl
+++ b/src/embed_lazy.jl
@@ -1,0 +1,99 @@
+"""
+    embed_lazy([basis_l[, basis_r]], indices, op)
+
+Lazily embed `op` into the composite Hilbert space described by `basis_l`
+(and `basis_r`), returning a structure-preserving lazy operator instead of the
+eagerly materialized matrix produced by [`embed`](@ref).
+
+In contrast to [`embed`](@ref), which allocates the full embedded matrix (e.g. a
+`2^n x 2^n` sparse matrix when embedding a one-site operator in an `n`-site
+basis), `embed_lazy` keeps the local tensor-product structure:
+
+- a `DataOperator` (or any other single-subsystem `AbstractOperator`) embedded at
+  a single index is returned as a [`LazyTensor`](@ref),
+- a [`LazyTensor`](@ref) is re-embedded into the larger basis, preserving its
+  suboperators and factor,
+- a [`LazySum`](@ref) is preserved as a `LazySum` whose terms are embedded lazily,
+- a [`TimeDependentSum`](@ref) is preserved, keeping its coefficients while
+  lazily embedding its static operator terms.
+
+The result can be multiplied by kets, used as a term inside a `LazySum`, and
+converted to a dense or sparse operator with `dense(...)`/`sparse(...)` only when
+explicitly requested.
+
+If both bases are given they must be `CompositeBasis`es; `indices` must be sorted,
+mirroring the requirements of [`LazyTensor`](@ref).
+
+A monolithic operator acting jointly on more than one subsystem (for example a
+two-qubit gate given as a single dense matrix) has no tensor-product structure to
+exploit and therefore cannot be embedded lazily. Such inputs raise an
+`ArgumentError`; use [`embed`](@ref) for an eager result, or pass the operator as
+a [`LazyTensor`](@ref)/[`LazySum`](@ref) with explicit local structure.
+
+# Examples
+```jldoctest
+julia> b0 = SpinBasis(1//2); b = b0 ⊗ b0 ⊗ b0 ⊗ b0;
+
+julia> embed_lazy(b, 2, sigmax(b0)) isa LazyTensor
+true
+
+julia> embed_lazy(b, 3, LazySum(sigmax(b0), 0.5*sigmaz(b0))) isa LazySum
+true
+```
+
+See also [`embed`](@ref), [`LazyTensor`](@ref), [`LazySum`](@ref).
+"""
+function embed_lazy end
+
+embed_lazy(basis::CompositeBasis, indices, op::AbstractOperator) =
+    embed_lazy(basis, basis, indices, op)
+embed_lazy(basis::CompositeBasis, index::Integer, op::AbstractOperator) =
+    embed_lazy(basis, basis, index, op)
+embed_lazy(basis::CompositeBasis, indices, op::TimeDependentSum) =
+    embed_lazy(basis, basis, indices, op)
+embed_lazy(basis::CompositeBasis, index::Integer, op::TimeDependentSum) =
+    embed_lazy(basis, basis, index, op)
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::AbstractOperator)
+    basis_l.bases[index] == op.basis_l || throw(IncompatibleBases())
+    basis_r.bases[index] == op.basis_r || throw(IncompatibleBases())
+    return LazyTensor(basis_l, basis_r, index, op)
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::AbstractOperator)
+    if length(indices) == 1
+        return embed_lazy(basis_l, basis_r, first(indices), op)
+    end
+    throw(ArgumentError(
+        "embed_lazy cannot lazily embed an operator of type $(typeof(op)) acting " *
+        "jointly on the subsystems $(collect(indices)): it has no tensor-product " *
+        "structure to preserve. Use `embed` for an eager result, or pass a " *
+        "LazyTensor/LazySum with explicit local structure."))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazyTensor)
+    idx = collect(indices)
+    issorted(idx) || throw(ArgumentError("embed_lazy requires sorted `indices`."))
+    reduce(tensor, basis_l.bases[idx]) == op.basis_l || throw(IncompatibleBases())
+    reduce(tensor, basis_r.bases[idx]) == op.basis_r || throw(IncompatibleBases())
+    # op.indices address the sub-basis spanned by `indices`; map them to the full basis
+    new_indices = idx[op.indices]
+    return LazyTensor(basis_l, basis_r, new_indices, op.operators, op.factor)
+end
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazyTensor)
+    return embed_lazy(basis_l, basis_r, [index], op)
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::LazySum)
+    LazySum(basis_l, basis_r, op.factors, map(o->embed_lazy(basis_l, basis_r, indices, o), op.operators))
+end
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::LazySum)
+    LazySum(basis_l, basis_r, op.factors, map(o->embed_lazy(basis_l, basis_r, index, o), op.operators))
+end
+
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::TimeDependentSum)
+    TimeDependentSum(coefficients(op), embed_lazy(basis_l, basis_r, index, static_operator(op)), op.current_time)
+end
+function embed_lazy(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::TimeDependentSum)
+    TimeDependentSum(coefficients(op), embed_lazy(basis_l, basis_r, indices, static_operator(op)), op.current_time)
+end

--- a/test/test_embed_lazy.jl
+++ b/test/test_embed_lazy.jl
@@ -1,0 +1,98 @@
+@testitem "test_embed_lazy" begin
+using Test
+using QuantumOpticsBase
+using Random, SparseArrays, LinearAlgebra
+
+@testset "embed_lazy" begin
+
+Random.seed!(0)
+
+b1 = NLevelBasis(3)
+b2 = SpinBasis(1//2)
+b3 = FockBasis(2)
+b = b1 ⊗ b2 ⊗ b3
+
+I2 = dense(identityoperator(b2))
+
+op1 = DenseOperator(b1, b1, rand(ComplexF64, length(b1), length(b1)))
+op2 = DenseOperator(b2, b2, rand(ComplexF64, length(b2), length(b2)))
+op3 = DenseOperator(b3, b3, rand(ComplexF64, length(b3), length(b3)))
+
+psi = Ket(b, rand(ComplexF64, length(b)))
+
+# single-index dense operator
+lz = embed_lazy(b, 1, op1)
+@test lz isa LazyTensor
+@test dense(lz) ≈ dense(embed(b, 1, op1))
+@test (lz * psi).data ≈ (embed(b, 1, op1) * psi).data
+
+lz = embed_lazy(b, 2, op2)
+@test lz isa LazyTensor
+@test dense(lz) ≈ dense(embed(b, 2, op2))
+@test (lz * psi).data ≈ (embed(b, 2, op2) * psi).data
+
+@test dense(embed_lazy(b, [3], op3)) ≈ dense(embed(b, 3, op3))
+
+# single-index sparse operator
+lz = embed_lazy(b, 1, sparse(op1))
+@test lz isa LazyTensor
+@test dense(lz) ≈ dense(embed(b, 1, op1))
+@test (lz * psi).data ≈ (embed(b, 1, op1) * psi).data
+
+@test dense(embed_lazy(b, b, 2, op2)) ≈ dense(embed(b, 2, op2))
+
+# LazySum stays a LazySum of lazily embedded terms, factors preserved
+local_h = LazySum([1.0, 0.5], (op2, sparse(op2)))
+lz = embed_lazy(b, 2, local_h)
+@test lz isa LazySum
+@test all(t -> t isa LazyTensor, lz.operators)
+@test dense(lz) ≈ dense(embed(b, 2, local_h))
+@test (lz * psi).data ≈ (embed(b, 2, local_h) * psi).data
+@test collect(lz.factors) == collect(local_h.factors)
+
+# re-embedding a LazyTensor across several subsystems keeps its suboperators and factor
+bsub = b1 ⊗ b3
+lt = LazyTensor(bsub, [1, 2], (op1, op3), 2.0)
+lz = embed_lazy(b, [1, 3], lt)
+@test lz isa LazyTensor
+@test lz.factor == lt.factor
+@test lz.indices == [1, 3]
+@test dense(lz) ≈ 2.0 * dense(op1 ⊗ I2 ⊗ op3)
+@test (lz * psi).data ≈ (2.0 * (op1 ⊗ I2 ⊗ op3) * psi).data
+
+# a LazyTensor occupying only some of the addressed sites maps indices correctly
+lt_partial = LazyTensor(bsub, [2], (op3,), 1.0)
+lz = embed_lazy(b, [1, 3], lt_partial)
+@test lz.indices == [3]
+@test dense(lz) ≈ dense(embed(b, 3, op3))
+
+lt_sp = LazyTensor(bsub, [1, 2], (sparse(op1), sparse(op3)), 1.0)
+@test dense(embed_lazy(b, [1, 3], lt_sp)) ≈ dense(op1 ⊗ I2 ⊗ op3)
+
+# TimeDependentSum keeps its coefficients and embeds the static terms lazily
+f = t -> 2.0 + 0.0im
+tds = TimeDependentSum([f], [op2])
+lz = embed_lazy(b, 2, tds)
+@test lz isa TimeDependentSum
+set_time!(lz, 1.3)
+eager = embed(b, 2, tds); set_time!(eager, 1.3)
+@test dense(static_operator(lz)) ≈ dense(static_operator(eager))
+@test static_operator(lz) isa LazySum
+@test all(t -> t isa LazyTensor, static_operator(lz).operators)
+
+@test_throws QuantumOpticsBase.IncompatibleBases embed_lazy(b, 1, op2)
+@test_throws QuantumOpticsBase.IncompatibleBases embed_lazy(b, [1, 3], LazyTensor(b1 ⊗ b2, [1, 2], (op1, op2), 1.0))
+
+@test_throws ArgumentError embed_lazy(b, [1, 3], op1 ⊗ op3)
+@test_throws ArgumentError embed_lazy(b, [3, 1], lt)
+
+# the lazy path must not materialize the full embedded matrix
+big = reduce(⊗, fill(b2, 10))
+sx = sigmax(b2)
+embed_lazy(big, 1, sx); embed(big, 1, sx)
+alloc_lazy = @allocated embed_lazy(big, 1, sx)
+alloc_eager = @allocated embed(big, 1, sx)
+@test alloc_lazy < alloc_eager
+
+end # testset
+end


### PR DESCRIPTION
## Summary

Adds a lazy operator-embedding API, `embed_lazy`, as requested in the unitaryHACK bounty issue qojulia/QuantumOptics.jl#523.

Where [`embed`](https://github.com/qojulia/QuantumOpticsBase.jl/blob/master/src/operators.jl) materializes the full embedded matrix (e.g. a `2^n × 2^n` sparse matrix to embed a one-site operator into an `n`-site basis), `embed_lazy` preserves the local tensor-product structure and returns a structure-preserving lazy operator. The result can be multiplied by kets, used as a term in a `LazySum`, and converted with `dense`/`sparse` only when explicitly requested.

```julia
b0 = SpinBasis(1//2)
b = b0 ⊗ b0 ⊗ b0 ⊗ b0          # composite basis
H = embed_lazy(b, 1, sigmax(b0)) + embed_lazy(b, 2, sigmaz(b0))
```

## What it does

- `DataOperator` / any single-subsystem `AbstractOperator` at a single index → `LazyTensor`
- `LazyTensor` re-embedded into the larger basis, preserving suboperators **and** factor (the suboperator indices are remapped through `indices`, so partial `LazyTensor`s embed correctly)
- `LazySum` preserved as a `LazySum` of lazily embedded terms, factors carried over
- `TimeDependentSum` preserved, keeping its coefficients while lazily embedding the static terms
- single- and multi-index forms, plus the explicit `embed_lazy(basis_l, basis_r, indices, op)` signature
- incompatible bases raise `IncompatibleBases`; unsorted `indices` raise `ArgumentError`

## API decisions (the points raised in the issue)

- **Name:** kept `embed_lazy` from PR #88, exported from `QuantumOpticsBase`.
- **Two-basis form:** `embed_lazy(basis_l, basis_r, indices, op)` is supported alongside the single-basis form.
- **Monolithic multi-site operators:** a single dense/sparse operator acting jointly on more than one subsystem has no tensor-product structure to keep, so it cannot be embedded lazily — these raise an informative `ArgumentError` pointing the user to `embed` or to passing a `LazyTensor`/`LazySum`. (`LazyProduct` is likewise left unsupported for now.)

## Note on the issue's example

The issue's minimal example writes `local_h = sx + 0.5*sz` and expects `embed_lazy(b, 3, local_h) isa LazySum`. In QuantumOpticsBase, `+` on two operators sharing a basis returns a single eager `Operator`, not a `LazySum`, so `embed_lazy` correctly returns a `LazyTensor` for that input. `embed_lazy` preserves a `LazySum` only when actually given one (e.g. `LazySum(sx, 0.5*sz)`); the tests and docstring use an explicit `LazySum` to reflect this.

## Tests & docs

- New `test/test_embed_lazy.jl`: single-index dense/sparse, the two-basis signature, `LazySum` preservation + factor carry-over, multi-index `LazyTensor` re-embedding (including a partial `LazyTensor` and sparse suboperators), `TimeDependentSum`, incompatible-basis and unsupported-operator failures, and an allocation check confirming the lazy path does not materialize the full matrix.
- Docstring with a runnable `jldoctest` and an `@docs` entry in `docs/src/api.md` next to `embed`.
- Verified locally on Julia 1.11.5: the new `test_embed_lazy` test set, the Aqua checks (no new ambiguities), the doctests, and JET on the new methods all pass.

## AI disclosure

I used Claude Code as an assistant to help me find my way around this large codebase and to help brainstorm and draft parts of the implementation, tests, and docstring. I drove the design decisions, reviewed and refined the code, and manually verified everything on Julia 1.11.5 — running the new `test_embed_lazy` set, the Aqua checks, the doctests, and JET. The clarification about `+` returning an eager operator (so `embed_lazy` returns a `LazyTensor`, not a `LazySum`, for the issue's example) and the choice to fail fast on unsorted `indices` both came from problems I hit and worked through while testing locally.
