### PR TITLE
Fix SciML state interface and downgrade CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 QuantumOpticsBaseMakieExt = ["Makie"]
 
 [compat]
-Adapt = "4.1"
+Adapt = "4.3"
 FFTW = "1.3.2"
 FastExpm = "1.1.0"
 FastGaussQuadrature = "0.5, 1"
@@ -39,7 +39,7 @@ Makie = "0.24"
 MKL_jll = "2021.1.1, 2025.2"
 QuantumInterface = "0.4"
 Random = "1"
-RecursiveArrayTools = "3.36, 4"
+RecursiveArrayTools = "3.52, 4"
 SciMLBase = "2.102.1, 3"
 SciMLOperators = "1.9"
 SparseArrays = "1"

--- a/src/states.jl
+++ b/src/states.jl
@@ -36,6 +36,7 @@ Base.eltype(::Type{K}) where {K <: Ket{B,V}} where {B,V} = eltype(V)
 Base.eltype(::Type{K}) where {K <: Bra{B,V}} where {B,V} = eltype(V)
 Base.size(x::Union{Bra,Ket}) = size(x.data)
 @inline Base.axes(x::Union{Bra,Ket}) = axes(x.data)
+Base.isempty(x::Union{Bra,Ket}) = isempty(x.data)
 
 Bra{B}(b::B, data::T) where {B,T} = Bra{B,T}(b, data)
 Ket{B}(b::B, data::T) where {B,T} = Ket{B,T}(b, data)

--- a/test/test_sciml_broadcast_interfaces.jl
+++ b/test/test_sciml_broadcast_interfaces.jl
@@ -9,6 +9,8 @@ using OrdinaryDiffEqLowOrderRK: DP5
 # ket ODE problem
 ℋ = SpinBasis(1//2)
 ↓ = spindown(ℋ)
+@test !isempty(↓)
+@test !isempty(adjoint(↓))
 t₀, t₁ = (0.0, pi)
 σx = sigmax(ℋ)
 iσx = im*σx


### PR DESCRIPTION
## Summary

- define Base.isempty for Bra and Ket by delegating to their backing data
- add direct state assertions to the existing SciML integration test
- raise only the root Project.toml lower bounds for Adapt (4.3) and RecursiveArrayTools (3.52, 4)
- leave test/Project.toml and the downgrade workflow unchanged

## Root cause

OrdinaryDiffEqCore started checking isempty(u0) during ODE initialization. QuantumOpticsBase states expose size and axes, but did not expose isempty, so Julia fell back to iteration and raised a MethodError for Ket.

The downgrade job pins each root dependency at its declared floor, then adds the test dependencies without re-resolving those pins. Adapt 4.1 and RecursiveArrayTools 3.36 restricted the resulting OrdinaryDiffEq stack to versions that require DataStructures 0.18, while the locked graph requires DataStructures 0.19.6 through OrderedCollections 2. Raising Adapt to 4.3 and RecursiveArrayTools to 3.52 selects a coherent SciML stack while preserving supported RecursiveArrayTools 3.x and 4.x releases.

## Validation

- Julia 1.12.6 with current compatible dependencies: 2,130 passed, 2 expected broken
- Julia 1.10.11 with the exact forcedeps action and allow_reresolve=false: 2,130 passed, 2 expected broken
- boundary probes confirm Adapt 4.1 and RecursiveArrayTools 3.51 still fail
- git diff --check
- independent final review: no blocking findings