### PR TITLE
Simplify downgrade CI on Julia 1.12

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -9,35 +9,32 @@ on:
     paths-ignore:
       - 'docs/**'
 
-concurrency:
-  # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
-  # Cancel intermediate builds, but only if it is a pull request build.
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+permissions:
+  contents: read
 
-env:
-  PYTHON: ~
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.10']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra,SparseArrays
-          mode: 'forcedeps'
-          julia_version: ${{ matrix.version }}
+          version: '1.12'
       - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - uses: julia-actions/julia-downgrade-compat@v2.7.0
+        with:
+          projects: '.,test'
+          skip: LinearAlgebra,Random,SparseArrays
+          mode: 'forcedeps'
+          julia_version: '1.12'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           allow_reresolve: false
           force_latest_compatible_version: false
-          test_args: general

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'min'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -32,9 +32,9 @@ jobs:
           projects: '.,test'
           skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
-          julia_version: '1.12'
+          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-          force_latest_compatible_version: false
+      - name: Run tests without re-resolving
+        env:
+          JULIA_LOAD_PATH: ${{ github.workspace }}/test:${{ github.workspace }}:@stdlib
+        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 'min'
+          version: '1.12'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -32,11 +32,8 @@ jobs:
           projects: '.,test'
           skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
-          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Instantiate the locked test environment
-        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
-      - name: Run tests without re-resolving
-        env:
-          JULIA_LOAD_PATH: ${{ github.workspace }}/test:${{ github.workspace }}:@stdlib
-        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -34,6 +34,8 @@ jobs:
           mode: 'forcedeps'
           julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Instantiate the locked test environment
+        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
       - name: Run tests without re-resolving
         env:
           JULIA_LOAD_PATH: ${{ github.workspace }}/test:${{ github.workspace }}:@stdlib


### PR DESCRIPTION
## Summary
- run lower-bound resolution and testing on Julia 1.12
- resolve root and split test environments together, then build and test the locked graph
- disable both `Pkg.test` re-resolution paths
- remove pre-1.12 setup, manifest-repair, workspace-rewrite, and direct-test workarounds
- retain strict `forcedeps` verification and only the required stdlib exclusions

No compat bounds are added to `test/Project.toml`.

## Validation
- `actionlint`
- all Project TOML files parsed with Julia 1.12
- aggregate workflow-contract and stdlib-skip checks
- targeted locked-manifest runs on representative and exceptional repositories
- two independent cross-repository reviews

Existing package lower-bound failures are intentionally left visible for separate follow-up.