### PR TITLE
Update JET target module configuration

### DIFF
--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -4,6 +4,6 @@ using QuantumOpticsBase
 using JET
 
 @testset "jet" begin
-    JET.test_package(QuantumOpticsBase, target_defined_modules = true)
+    JET.test_package(QuantumOpticsBase, target_modules = (QuantumOpticsBase,))
 end # testset
 end


### PR DESCRIPTION
## Summary

- replace the removed `target_defined_modules` option with `target_modules`
- retain package-only analysis with the tuple form used by other packages in this workspace

## Validation

- `JET_TEST=true JULIA_NUM_THREADS=auto julia --project=. -e 'using Pkg; Pkg.test()'`\n- Julia 1.12.6 with JET 0.12.1: 1 test passed