### PR TITLE
Cap OrdinaryDiffEqCore at 4.13 in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,6 +7,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 QuantumInterface = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
@@ -21,4 +22,5 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Aqua = "0.8.14"
+OrdinaryDiffEqCore = "0 - 4.13"
 TestItemRunner = "1.1.5"


### PR DESCRIPTION
## Summary

- add OrdinaryDiffEqCore as an explicit test dependency
- constrain the test environment to Core versions through 4.13
- keep the lower end open so the downgrade workflow retains the older supported SciML graph

## Context

The current registry resolution combines OrdinaryDiffEqLowOrderRK 2.2.2 with OrdinaryDiffEqCore 4.14.x. LowOrderRK 2.2.2 imports Core APIs that were removed in 4.14, so CI fails during precompilation before QuantumOpticsBase tests run.

This is a temporary test-only constraint while [JuliaRegistries/General#163934](https://github.com/JuliaRegistries/General/pull/163934) applies the corresponding retroactive registry compatibility bound.

## Verification

- Julia 1.12.6 latest-compatible `Pkg.test()`: 2,130 passed, 2 broken; resolved LowOrderRK 2.2.2 and Core 4.13.0
- CI-equivalent `julia-downgrade-compat@v2.7.0`, build, and `Pkg.test(; allow_reresolve=false)`: 2,130 passed, 2 broken; resolved LowOrderRK 1.12.0 and Core 3.26.0
- `git diff --check`