### PR TITLE
Precompile representative usage workloads

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,1 +1,130 @@
 using PrecompileTools
+
+@setup_workload let
+    # Fock-space states and operators
+    fock_basis = FockBasis(20)
+    alpha = 1.2
+
+    @compile_workload begin
+        annihilation = destroy(fock_basis)
+        state = coherentstate(fock_basis, alpha)
+        density = dm(state)
+        derivative = -1im * (annihilation + create(fock_basis)) * state
+
+        amplitude = expect(annihilation, state)
+        photon_number = expect(number(fock_basis), density)
+        @assert isapprox(amplitude, alpha; atol=1e-10)
+        @assert isapprox(photon_number, abs2(alpha); atol=1e-9)
+        @assert isapprox(tr(density), 1; atol=1e-12)
+        @assert isfinite(norm(derivative))
+    end
+end
+
+@setup_workload let
+    # Composite systems, embedding, and partial traces
+    fock_basis = FockBasis(20)
+    spin_basis = SpinBasis(1 // 2)
+
+    @compile_workload begin
+        raising = sigmap(spin_basis)
+        lowering = sigmam(spin_basis)
+        atom_hamiltonian = 2 * raising * lowering
+
+        annihilation = destroy(fock_basis)
+        field_hamiltonian = number(fock_basis)
+        interaction = annihilation ⊗ raising + create(fock_basis) ⊗ lowering
+
+        composite_basis = fock_basis ⊗ spin_basis
+        hamiltonian =
+            embed(composite_basis, 1, field_hamiltonian) +
+            embed(composite_basis, 2, atom_hamiltonian) +
+            interaction
+        initial_state = fockstate(fock_basis, 1) ⊗ spindown(spin_basis)
+        derivative = hamiltonian * initial_state
+        reduced_field = ptrace(dm(initial_state), 2)
+
+        @assert basis(derivative) == composite_basis
+        @assert isapprox(tr(reduced_field), 1; atol=1e-12)
+        @assert isfinite(norm(derivative))
+    end
+end
+
+@setup_workload let
+    # Entanglement metrics
+    spin_basis = SpinBasis(1 // 2)
+
+    @compile_workload begin
+        up = spinup(spin_basis)
+        down = spindown(spin_basis)
+        state = (up ⊗ down - down ⊗ up) / sqrt(2)
+        density = dm(state)
+        reduced_spin = ptrace(density, 2)
+
+        entropy = real(entropy_vn(reduced_spin))
+        state_negativity = negativity(density, 1)
+        self_fidelity = real(fidelity(reduced_spin, reduced_spin))
+        @assert isapprox(tr(reduced_spin), 1; atol=1e-12)
+        @assert isapprox(entropy, log(2); atol=1e-12)
+        @assert isapprox(state_negativity, 0.5; atol=1e-12)
+        @assert isapprox(self_fidelity, 1; atol=1e-12)
+    end
+end
+
+@setup_workload let
+    # Lindblad superoperators
+    fock_basis = FockBasis(10)
+
+    @compile_workload begin
+        hamiltonian = number(fock_basis)
+        jump = destroy(fock_basis)
+        generator = liouvillian(hamiltonian, [jump])
+        density = dm(coherentstate(fock_basis, 0.5))
+        derivative = generator * density
+
+        @assert isapprox(tr(derivative), 0; atol=1e-11)
+        @assert isfinite(norm(derivative))
+    end
+end
+
+@setup_workload let
+    # Time-dependent operators
+    spin_basis = SpinBasis(1 // 2)
+    sample_time = 0.25
+
+    @compile_workload begin
+        sx = sigmax(spin_basis)
+        sz = sigmaz(spin_basis)
+        operator = TimeDependentSum((cos, sin), (sx, sz))
+        set_time!(operator, sample_time)
+
+        state = spinup(spin_basis)
+        result = operator * state
+        expected = (cos(sample_time) * sx + sin(sample_time) * sz) * state
+        @assert current_time(operator) == sample_time
+        @assert norm(result - expected) < 1e-12
+    end
+end
+
+@setup_workload let
+    # Bosonic many-body operators
+    one_body_basis = NLevelBasis(2)
+
+    @compile_workload begin
+        many_body_basis = ManyBodyBasis(
+            one_body_basis,
+            bosonstates(one_body_basis, [0, 1, 2, 3]),
+        )
+        one_body_hamiltonian = diagonaloperator(one_body_basis, [0.0, 1.0])
+        many_body_hamiltonian = manybodyoperator(
+            many_body_basis,
+            one_body_hamiltonian,
+        )
+
+        state = basisstate(many_body_basis, [1, 2])
+        transferred = transition(many_body_basis, 1, 2) * state
+        expected = 2 * basisstate(many_body_basis, [2, 1])
+        energy = real(expect(many_body_hamiltonian, state))
+        @assert isapprox(energy, 2; atol=1e-12)
+        @assert norm(transferred - expected) < 1e-12
+    end
+end

--- a/test/test_superoperators.jl
+++ b/test/test_superoperators.jl
@@ -171,12 +171,12 @@ op2 = DenseOperator(spinbasis, [0.2+0.1im 0.1+2.3im; 0.8+4.0im 0.3+1.4im])
 @test tracedistance(spost(op1)*op2, op2*op1) < 1e-12
 @test tracedistance(ChoiState(spost(op1))*op2, op2*op1) < 1e-12
 
-@test spre(sparse(op1))*op2 == op1*op2
-@test ChoiState(spre(sparse(op1)))*op2 == op1*op2
-@test spost(sparse(op1))*op2 == op2*op1
-@test ChoiState(spost(sparse(op1)))*op2 == op2*op1
-@test spre(sparse(dagger(op1)))*op2 == dagger(op1)*op2
-@test ChoiState(spre(sparse(dagger(op1))))*op2 == dagger(op1)*op2
+@test spre(sparse(op1))*op2 ≈ op1*op2
+@test ChoiState(spre(sparse(op1)))*op2 ≈ op1*op2
+@test spost(sparse(op1))*op2 ≈ op2*op1
+@test ChoiState(spost(sparse(op1)))*op2 ≈ op2*op1
+@test spre(sparse(dagger(op1)))*op2 ≈ dagger(op1)*op2
+@test ChoiState(spre(sparse(dagger(op1))))*op2 ≈ dagger(op1)*op2
 @test spre(dense(dagger(op1)))*op2 ≈ dagger(op1)*op2
 @test ChoiState(spre(dense(dagger(op1))))*op2 ≈ dagger(op1)*op2
 @test sprepost(sparse(op1), op1)*op2 ≈ op1*op2*op1


### PR DESCRIPTION
## Stack

#248 is merged. This branch is rebased directly onto its squash-merge commit, `be132ba`.

## Summary

- add deterministic `PrecompileTools` workloads for representative public usage
- cover Fock-space states and operators, composite systems, density metrics, Lindblad superoperators, time-dependent operators, and bosonic many-body operators
- keep each domain in an isolated `@setup_workload` / `@compile_workload` block with self-consistency assertions
- avoid random state, anonymous function types, FFT planning, optional extensions, and persistent global mutations
- use approximate comparisons for six sparse-superoperator products whose exact equality changed under Julia 1.12.7 by at most `1.78e-15`

The workload structure follows the example-workload stage in [QuantumSavory.jl#530](https://github.com/QuantumSavory/QuantumSavory.jl/pull/530). The comparison change is limited to the six failing assertions; adjacent sparse-to-sparse exact comparisons remain unchanged.

## Latency result

A reportable local comparison against #248 used five independent cache builds, four recorded samples per build, counterbalanced base/head order, and the same saved consumer environment for both variants.

| Scenario | First call before | First call after | Change |
|---|---:|---:|---:|
| Fock | 909 ms | 141 ms | -85% |
| Composite | 1,586 ms | 187 ms | -88% |
| Metrics | 7,910 ms | 1,370 ms | -83% |
| Superoperator | 1,514 ms | 129 ms | -91% |
| Time-dependent | 851 ms | 53 ms | -94% |
| Many-body | 1,468 ms | 22 ms | -99% |

All five builds showed a material total-latency improvement in every scenario. Median package-cache construction increased from 1.83 s to 8.64 s, cache size from 2.55 MiB to 20.65 MiB, and import time by approximately 33 ms.

## Validation

- focused `test_superoperators` item on Julia 1.10.11 and 1.12.7: 110 passed
- `Pkg.test()` on Julia 1.12.7: 2,130 passed, 2 expected broken
- `Pkg.precompile()` and package import on Julia 1.10.11, 1.12.6, and 1.12.7
- import with `--compiled-modules=no` on supported Julia 1.10 and 1.12 versions
- all six target scenarios in fresh processes on Julia 1.10.11 and 1.12.6
- reportable five-build, four-sample six-scenario cold-start harness comparison
- whitespace and diff checks
