### PR TITLE
Add trace-derived precompile statements

### DIFF
--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -107,5 +107,6 @@ include("printing.jl")
 include("apply.jl")
 include("visualization.jl")
 include("precompile.jl")
+include("precompile_statements.jl")
 
 end # module

--- a/src/precompile_statements.jl
+++ b/src/precompile_statements.jl
@@ -1,0 +1,17 @@
+# Generated from the cold-start scenarios on Julia 1.12.6 (x86_64-linux-gnu).
+# Each raw trace was filtered with sortprecompile.py revision
+# 4ea3c813d9a5adc494d84368e08825f5d765a0a6 using `-m 50.000001`.
+# Timing comments preserve the largest observation for each exact statement.
+# Recompilations and signatures tied to scenarios, value-specific FFT plans,
+# generated names, compiler internals, or modules not bound in QuantumOpticsBase
+# are excluded. These observations select statements; they are not benchmarks.
+
+using PrecompileTools: @setup_workload
+
+@setup_workload begin
+    #=  106.9 ms =# precompile(Tuple{typeof(Base.:(*)), Array{Base.Complex{Float64}, 1}, LinearAlgebra.Adjoint{Base.Complex{Float64}, Array{Base.Complex{Float64}, 1}}})
+    #=  105.5 ms =# precompile(Tuple{typeof(Base.:(*)), LinearAlgebra.Adjoint{Base.Complex{Float64}, SparseArrays.SparseMatrixCSC{Base.Complex{Float64}, Int64}}, Array{Base.Complex{Float64}, 2}, SparseArrays.SparseMatrixCSC{Base.Complex{Float64}, Int64}})
+    #=   73.7 ms =# precompile(Tuple{typeof(Base.Broadcast.materialize), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Nothing, typeof(Base.real), Tuple{Array{Base.Complex{Float64}, 2}}}})
+    #=   67.3 ms =# precompile(Tuple{typeof(Base.:(/)), Array{Base.Complex{Float64}, 2}, Float64})
+    #=   58.6 ms =# precompile(Tuple{typeof(Base.:(/)), Array{Base.Complex{Float64}, 2}, Int64})
+end


### PR DESCRIPTION
## Stack

#248 and #249 are merged. This branch is rebased directly onto the #249 squash-merge commit, `c1c70a0`. Its incremental diff is only the trace-derived statements and their module include.

## Summary

- add five explicit precompile directives selected from residual Julia 1.12.6 compile traces
- keep the generated statements in a separate `src/precompile_statements.jl`, loaded after the representative workloads
- retain timing provenance in comments and document the portability exclusions

This follows the trace-derived stage in [QuantumSavory.jl#536](https://github.com/QuantumSavory/QuantumSavory.jl/pull/536).

## Trace generation and filtering

The traces were generated from the historical #249 workload commit `c4ea75f` after building its package cache in a fresh, dedicated depot. The merged #249 commit `c1c70a0` has byte-identical `Project.toml` and `src/` inputs. The rebased #250 head `2a6f8d3` also has a complete tree byte-identical to the previously validated head `0897e5e`, so the trace inputs and package-cache behavior are unchanged.

Each of the ten cold-start scenarios ran in a separate Julia 1.12.6 process with:

```text
--trace-compile=PATH --trace-compile-timing
```

The run produced 724 timed raw lines. Each file was filtered with [sortprecompile.py](https://gist.github.com/KristofferC/f9abc44418f9474baa0d30b1c3e764d4) by Kristoffer Carlsson, pinned at revision `4ea3c813d9a5adc494d84368e08825f5d765a0a6` (raw SHA-256 `2ca2fb16cab2c166442f7cb501afaa597b1992b3d77420d3e96903206d9c08a4`):

```text
-m 50.000001
```

The small epsilon is intentional because the filter retains observations greater than or equal to its threshold; this selects strictly longer than 50 ms.

Filtering produced 29 observations and 20 exact unique statements. Five portable statements remain after excluding scenario-local `Main` methods and dictionary construction, a compiler internal, generated Pauli closure names, and a particle signature tied to exact basis bounds and concrete FFTW plan types. There were no recompilation lines. Every retained statement returns `true` inside `QuantumOpticsBase` on Julia 1.10.11 and 1.12.6.

## Latency result

A reportable comparison against #249 used five independent cache builds, four recorded samples per build, counterbalanced base/head order, and the same saved consumer environment.

- Pauli first call: 2,065 ms -> 1,656 ms (-20%)
- Pauli total latency: 2,645 ms -> 2,237 ms (-15%)
- material Pauli improvement: 5 better, 0 worse out of 5 builds
- cache build: 8.73 s -> 8.97 s (+0.24 s)
- cache size: 20.65 MiB -> 21.87 MiB (+1.22 MiB)
- import, Fock, and composite latency: no material change

## Validation

- rebased complete tree verified byte-identical to the previously validated #250 head
- pinned filter output reproduced independently for all ten trace files
- all retained statements validated on Julia 1.10.11 and 1.12.6
- `Pkg.precompile()` and package import on Julia 1.10.11, 1.12.6, and 1.12.7
- import with `--compiled-modules=no` on Julia 1.10.11 and 1.12.7
- all ten scenarios in fresh Julia 1.12.6 processes and Pauli on Julia 1.10.11
- reportable five-build, four-sample Fock/composite/Pauli harness comparison
- merged #249 baseline `Pkg.test()` on Julia 1.12.7: 2,130 passed, 2 expected broken
- Julia syntax, whitespace, and diff checks
