### PR TITLE
Reduce method invalidations during package loading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,6 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -47,5 +46,4 @@ SciMLOperators = "1.22"
 SparseArrays = "1"
 SpecialFunctions = "2.1.4"
 Strided = "1, 2"
-UnsafeArrays = "1"
 julia = "1.10"

--- a/benchmark/precompile/README.md
+++ b/benchmark/precompile/README.md
@@ -15,15 +15,16 @@ benchmark/precompile/run.sh /tmp/quantumopticsbase-precompile-results \
 
 The first variant is the default baseline. Each variant must be a clean,
 committed checkout, and all variants must have identical `Project.toml` files
-apart from the top-level package version. The one bootstrap exception permits
-only the exact `PrecompileTools` dependency and compatibility entries added by
-the CI setup PR. A run that uses this exception is non-reportable.
+apart from the top-level package version. Exact exceptions permit only the
+`PrecompileTools` dependency and compatibility entries added by the CI setup PR,
+or the `UnsafeArrays` entries removed after its final use was deleted. A run that
+uses either exception is non-reportable.
 The output directory must be outside every measured checkout. The harness
 refuses to overwrite existing result files. By default, it resolves one
 consumer Manifest from the last variant and points it at each checkout in turn.
-For the one-time bootstrap comparison, it instead selects a variant with the
-added `PrecompileTools` entries so the older baseline loads through the
-dependency-superset Manifest. It creates one seed
+For an exact metadata exception, it instead selects the variant with the
+dependency superset, so both variants load through the same resolved Manifest.
+It creates one seed
 depot with dependency caches and a new writable depot for every QuantumOpticsBase
 package-cache build. Dependency setup may access package servers. After setup,
 cache builds and samples run with package offline mode enabled. For reportable
@@ -121,10 +122,10 @@ setting `QOB_PRECOMPILE_ALLOW_JULIA_MISMATCH=1` or
 version matches or the checkout is clean. A run also records
 `reportable=false` when it uses fewer than five builds, fewer than four samples
 per build, omits either `fock` or `composite` from the common scenarios, or
-uses the `PrecompileTools` bootstrap metadata exception.
+uses either exact package-metadata exception.
 Thus the small default run and the descriptive pull-request workflow are
 explicitly non-reportable. A run that satisfies these repetition and headline
-requirements without an override or bootstrap difference records
+requirements without an override or package-metadata difference records
 `reportable=true` and an empty
 `nonreportable_reasons` list.
 

--- a/benchmark/precompile/run.sh
+++ b/benchmark/precompile/run.sh
@@ -79,6 +79,40 @@ project_has_bootstrap_precompiletools() {
     ' "$1"
 }
 
+project_without_unsafearrays() {
+    awk '
+        /^\[/ { section = $0 }
+        section == "" && /^version = / { next }
+        section == "[deps]" && $0 == "UnsafeArrays = \"c4a57d5a-5b31-53a6-b365-19f8c011fbd6\"" { next }
+        section == "[compat]" && $0 == "UnsafeArrays = \"1\"" { next }
+        { print }
+    ' "$1"
+}
+
+project_has_exact_unsafearrays() {
+    awk '
+        /^\[/ { section = $0 }
+        section == "[deps]" && /^[[:space:]]*UnsafeArrays[[:space:]]*=/ {
+            dependency_entries += 1
+            $0 == "UnsafeArrays = \"c4a57d5a-5b31-53a6-b365-19f8c011fbd6\"" && exact_dependency_entries += 1
+        }
+        section == "[compat]" && /^[[:space:]]*UnsafeArrays[[:space:]]*=/ {
+            compat_entries += 1
+            $0 == "UnsafeArrays = \"1\"" && exact_compat_entries += 1
+        }
+        END { exit !(dependency_entries == 1 && exact_dependency_entries == 1 && compat_entries == 1 && exact_compat_entries == 1) }
+    ' "$1"
+}
+
+project_lacks_unsafearrays() {
+    awk '
+        /^\[/ { section = $0 }
+        (section == "[deps]" || section == "[compat]") &&
+            /^[[:space:]]*UnsafeArrays[[:space:]]*=/ { entries += 1 }
+        END { exit !(entries == 0) }
+    ' "$1"
+}
+
 [[ $# -ge 3 ]] || usage
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
@@ -383,10 +417,17 @@ verify_checkout() {
 
 bootstrap_project_difference=false
 bootstrap_seed_index=
+unsafearrays_project_difference=false
+unsafearrays_seed_index=
 if project_has_bootstrap_precompiletools "${checkouts[0]}/Project.toml"; then
     baseline_has_bootstrap_precompiletools=true
 else
     baseline_has_bootstrap_precompiletools=false
+fi
+if project_has_exact_unsafearrays "${checkouts[0]}/Project.toml"; then
+    baseline_has_exact_unsafearrays=true
+else
+    baseline_has_exact_unsafearrays=false
 fi
 for index in "${!checkouts[@]}"; do
     ((index > 0)) || continue
@@ -396,24 +437,41 @@ for index in "${!checkouts[@]}"; do
         <(project_without_version "$checkout/Project.toml"); then
         continue
     fi
-    cmp -s -- \
+    if cmp -s -- \
         <(project_without_bootstrap_precompiletools "${checkouts[0]}/Project.toml") \
-        <(project_without_bootstrap_precompiletools "$checkout/Project.toml") || {
-        echo "all variants must use identical Project.toml dependency metadata, apart from the PrecompileTools bootstrap" >&2
-        exit 1
-    }
-    if project_has_bootstrap_precompiletools "$checkout/Project.toml"; then
-        candidate_has_bootstrap_precompiletools=true
-    else
-        candidate_has_bootstrap_precompiletools=false
+        <(project_without_bootstrap_precompiletools "$checkout/Project.toml"); then
+        if project_has_bootstrap_precompiletools "$checkout/Project.toml"; then
+            candidate_has_bootstrap_precompiletools=true
+        else
+            candidate_has_bootstrap_precompiletools=false
+        fi
+        [[ $baseline_has_bootstrap_precompiletools == false && $candidate_has_bootstrap_precompiletools == true ]] || {
+            echo "the PrecompileTools bootstrap exception permits only the exact dependency and compatibility entries added to a candidate" >&2
+            exit 1
+        }
+        bootstrap_project_difference=true
+        bootstrap_seed_index=$index
+        continue
     fi
-    [[ $baseline_has_bootstrap_precompiletools == false && $candidate_has_bootstrap_precompiletools == true ]] || {
-        echo "the PrecompileTools bootstrap exception permits only the exact dependency and compatibility entries added to a candidate" >&2
-        exit 1
-    }
-    bootstrap_project_difference=true
-    bootstrap_seed_index=$index
+    if cmp -s -- \
+        <(project_without_unsafearrays "${checkouts[0]}/Project.toml") \
+        <(project_without_unsafearrays "$checkout/Project.toml"); then
+        [[ $baseline_has_exact_unsafearrays == true ]] &&
+            project_lacks_unsafearrays "$checkout/Project.toml" || {
+            echo "the UnsafeArrays removal exception requires the exact baseline entries and no candidate entries" >&2
+            exit 1
+        }
+        unsafearrays_project_difference=true
+        unsafearrays_seed_index=0
+        continue
+    fi
+    echo "all variants must use identical Project.toml dependency metadata, apart from a supported exact exception" >&2
+    exit 1
 done
+[[ $bootstrap_project_difference == false || $unsafearrays_project_difference == false ]] || {
+    echo "the PrecompileTools bootstrap and UnsafeArrays removal exceptions cannot be combined" >&2
+    exit 1
+}
 for extra_label in "${extra_scenario_labels[@]}"; do
     known_label=false
     for label in "${labels[@]}"; do
@@ -537,10 +595,12 @@ cp -- "$script_dir/summarize.jl" "$summarize_script"
 chmod 0444 "$scenario_script" "$summarize_script"
 verify_harness_snapshots
 # Seed dependency caches through separate inodes so setup cannot page-warm a measured checkout.
-# The last variant normally supplies the dependency graph. A one-time
-# PrecompileTools bootstrap comparison uses a verified dependency-superset variant.
+# The last variant normally supplies the dependency graph. Exact metadata
+# exceptions use a verified dependency-superset variant.
 if [[ $bootstrap_project_difference == true ]]; then
     seed_index=$bootstrap_seed_index
+elif [[ $unsafearrays_project_difference == true ]]; then
+    seed_index=$unsafearrays_seed_index
 else
     seed_index=$((${#labels[@]} - 1))
 fi
@@ -730,6 +790,7 @@ non_reportable_reasons=()
 [[ $builds -ge 5 ]] || non_reportable_reasons+=(fewer_than_five_builds)
 [[ $samples -ge 4 ]] || non_reportable_reasons+=(fewer_than_four_samples_per_build)
 [[ $bootstrap_project_difference == false ]] || non_reportable_reasons+=(precompiletools_bootstrap_metadata_difference)
+[[ $unsafearrays_project_difference == false ]] || non_reportable_reasons+=(unsafearrays_removal_metadata_difference)
 [[ ",${scenario_list}," == *,fock,* ]] || non_reportable_reasons+=(missing_fock_headline)
 [[ ",${scenario_list}," == *,composite,* ]] || non_reportable_reasons+=(missing_composite_headline)
 if [[ ${#non_reportable_reasons[@]} -eq 0 ]]; then

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -1,6 +1,6 @@
 module QuantumOpticsBase
 
-using SparseArrays, LinearAlgebra, LRUCache, Strided, UnsafeArrays, FillArrays
+using SparseArrays, LinearAlgebra, LRUCache, Strided, FillArrays
 import LinearAlgebra: mul!, rmul!
 import RecursiveArrayTools
 

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -358,9 +358,9 @@ struct OccupationNumbers{StatisticsT,T} <: AbstractVector{T}
     occupations::Vector{T}
 end
 Base.size(on::OccupationNumbers) = size(on.occupations)
-Base.@propagate_inbounds Base.getindex(on::OccupationNumbers, v...) = getindex(on.occupations, v...)
-Base.@propagate_inbounds Base.setindex!(on::OccupationNumbers, value, v...) =
-    setindex!(on.occupations, value, v...)
+Base.@propagate_inbounds Base.getindex(on::OccupationNumbers, i::Int) = on.occupations[i]
+Base.@propagate_inbounds Base.setindex!(on::OccupationNumbers, value, i::Int) =
+    setindex!(on.occupations, value, i)
 Base.IndexStyle(::Type{<:OccupationNumbers}) = Base.IndexLinear()
 Base.similar(occ::OccupationNumbers, ::Type{T}, dims::Dims) where {T} =
     OccupationNumbers(occ.statistics, similar(occ.occupations, T, dims))

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -362,10 +362,14 @@ Base.@propagate_inbounds Base.getindex(on::OccupationNumbers, i::Int) = on.occup
 Base.@propagate_inbounds Base.setindex!(on::OccupationNumbers, value, i::Int) =
     setindex!(on.occupations, value, i)
 Base.IndexStyle(::Type{<:OccupationNumbers}) = Base.IndexLinear()
-Base.similar(occ::OccupationNumbers, ::Type{T}, dims::Dims) where {T} =
-    OccupationNumbers(occ.statistics, similar(occ.occupations, T, dims))
-Base.similar(::Type{OccupationNumbers{StatisticsT,T}}, dims::Dims) where {StatisticsT,T} =
-    OccupationNumbers(StatisticsT(), similar(Vector{T}, dims))
+function Base.similar(occ::OccupationNumbers, ::Type{T}, dims::Dims) where {T}
+    data = similar(occ.occupations, T, dims)
+    return length(dims) == 1 ? OccupationNumbers(occ.statistics, data) : data
+end
+function Base.similar(::Type{OccupationNumbers{StatisticsT,T}}, dims::Dims) where {StatisticsT,T}
+    data = Array{T}(undef, dims)
+    return length(dims) == 1 ? OccupationNumbers(StatisticsT(), data) : data
+end
 Base.isless(occ1::OccupationNumbers, occ2::OccupationNumbers) = occ1.occupations < occ2.occupations
 Base.copyto!(dest::OccupationNumbers, src::OccupationNumbers) = copyto!(dest.occupations, src.occupations)
 Base.convert(::Type{OccupationNumbers{StatisticsT,T}}, occ::AbstractVector) where {StatisticsT,T} =

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,7 +17,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Aqua = "0.8.14"

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -43,6 +43,21 @@ b2 = GenericBasis(130)
 @test collect(fermionstates(FermionBitstring{BigInt}, b2, 2)) ==
     convert.(FermionBitstring{BigInt}, fermionstates(b2, 2))
 
+# Test the AbstractVector indexing interface used by occupation states
+occupations = first(bosonstates(GenericBasis(3), 2))
+expected_occupations = collect(occupations)
+@test occupations[CartesianIndex(2)] == occupations[2, CartesianIndex()] ==
+    expected_occupations[2]
+@test collect(occupations[1:2]) == expected_occupations[1:2]
+@test collect(occupations[:]) == expected_occupations
+@test collect(occupations[[3, 1]]) == expected_occupations[[3, 1]]
+buffer = similar(occupations)
+copyto!(buffer, occupations)
+buffer[CartesianIndex(2)] = 7
+buffer[1, CartesianIndex()] = 8
+buffer[1:2] = [4, 5]
+@test collect(buffer)[1:2] == [4, 5]
+
 # Test basisstate
 b_mb = ManyBodyBasis(b, bosonstates(b, 2))
 psi_mb = basisstate(b_mb, [2, 0, 0, 0, 0])

--- a/test/test_manybody.jl
+++ b/test/test_manybody.jl
@@ -50,7 +50,14 @@ expected_occupations = collect(occupations)
     expected_occupations[2]
 @test collect(occupations[1:2]) == expected_occupations[1:2]
 @test collect(occupations[:]) == expected_occupations
-@test collect(occupations[[3, 1]]) == expected_occupations[[3, 1]]
+gathered_occupations = occupations[[3, 1]]
+@test gathered_occupations isa typeof(occupations)
+@test collect(gathered_occupations) == expected_occupations[[3, 1]]
+matrix_indices = reshape([1, 3], 1, 2)
+@test occupations[matrix_indices] == expected_occupations[matrix_indices]
+@test similar(occupations, (1, 2)) isa Matrix{Int}
+@test similar(typeof(occupations), (2,)) isa typeof(occupations)
+@test similar(typeof(occupations), (1, 2)) isa Matrix{Int}
 buffer = similar(occupations)
 copyto!(buffer, occupations)
 buffer[CartesianIndex(2)] = 7


### PR DESCRIPTION
## Summary

- remove the unused `UnsafeArrays` import and direct dependency
- implement the canonical scalar `AbstractVector` indexing interface for `OccupationNumbers`, leaving nonscalar indexing to Base
- cover Cartesian, range, colon, one-dimensional and shaped gather, and mutation indexing paths
- let the cold-start harness compare this exact dependency removal through a shared dependency-superset Manifest

One-dimensional nonscalar indexing preserves the `OccupationNumbers` wrapper and its statistics metadata. Shaped gather indexing returns an ordinary array, as required by the `AbstractVector` interface.

## Invalidation analysis

Measurements used fresh, single-threaded Julia processes with Julia 1.12.6, SnoopCompile 3.2.7, and SnoopCompileCore 3.1.2. Counts come from `uinvalidated` and `invalidation_trees` after `@snoop_invalidations`.

| Capture | Unique invalidated MIs | Consolidated trees | Tree-node occurrences |
|---|---:|---:|---:|
| `using QuantumOpticsBase` | 728 → 727 | 28 → 28 | 1,128 → 1,126 |
| `using QuantumOptics` | 1,523 → 1,517 | 265 → 257 | 11,753 → 11,688 |

Within the `QuantumOptics` workload, QuantumOpticsBase-caused invalidations changed as follows:

- cause trees: 6 → 4
- node occurrences: 188 → 166
- unique victims: 100 → 83

On Julia 1.10.12, the isolated QuantumOpticsBase load changed from 682 to 676 unique invalidated MethodInstances, 28 to 25 consolidated trees, and 1,268 to 1,259 tree-node occurrences.

Loading all direct dependencies before QuantumOpticsBase produced no invalidated MethodInstances. The four remaining QuantumOpticsBase cause trees in the downstream workload are required `norm` and `any` interfaces. A consolidation experiment reduced repeated tree occurrences but did not reduce `uinvalidated`, so those methods remain unchanged.

These are structural invalidation counts, not elapsed-latency measurements.

## Cold-start workflow

The existing benchmark requires identical package dependency metadata. This PR adds an exact exception for removing the known `UnsafeArrays` dependency and compatibility entries. The guard rejects partial, reversed, or unrelated metadata changes, resolves from the dependency-superset baseline, and marks the comparison non-reportable.

## Validation

- Julia 1.12.6 `Pkg.test()`: 2,140 passed, 2 expected broken, 0 failed
- Julia 1.12.6 `test_manybody` item: 1,274 passed
- Julia 1.10.12 targeted indexing probe
- final Julia 1.10.12 and 1.12.6 `@snoop_invalidations` captures
- base/head cold-start harness smoke: Fock and composite scenarios passed
- harness guards rejected partial and unrelated dependency metadata fixtures
- `bash -n benchmark/precompile/run.sh`
- `git diff --check`

The full Julia 1.10 suite and non-Linux platforms were not run locally.
