### PR TITLE
Remove unused UnsafeArrays dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,6 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -47,5 +46,4 @@ SciMLOperators = "1.22"
 SparseArrays = "1"
 SpecialFunctions = "2.1.4"
 Strided = "1, 2"
-UnsafeArrays = "1"
 julia = "1.10"

--- a/src/QuantumOpticsBase.jl
+++ b/src/QuantumOpticsBase.jl
@@ -1,6 +1,6 @@
 module QuantumOpticsBase
 
-using SparseArrays, LinearAlgebra, LRUCache, Strided, UnsafeArrays, FillArrays
+using SparseArrays, LinearAlgebra, LRUCache, Strided, FillArrays
 import LinearAlgebra: mul!, rmul!
 import RecursiveArrayTools
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,7 +17,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Aqua = "0.8.14"


### PR DESCRIPTION
## Summary

- remove the unused `UnsafeArrays` import and direct dependency
- remove the redundant `UnsafeArrays` test dependency

This supersedes #251 with a dependency-removal-only change.

## Validation

- Julia 1.12.6 `Pkg.test()`: 2,130 passed, 2 expected broken, 0 failed
- clean package load on Julia 1.12.6 and Julia 1.10.12
- no remaining tracked `UnsafeArrays` references
- `git diff --check`

## CI note

The existing cold-start workflow requires identical base/head dependency metadata except for its historical `PrecompileTools` exception. Its comparison job is therefore expected to stop at that guard. This PR intentionally leaves the benchmark harness unchanged to keep the code diff limited to removing `UnsafeArrays`.
