### PR TITLE
Reduce inference latency in Pauli and time-dependent workflows

### DIFF
--- a/src/pauli.jl
+++ b/src/pauli.jl
@@ -153,9 +153,28 @@ Generate a matrix of basis vectors in the Pauli representation given a number
 of qubits.
 """
 function pauli_basis_vectors(num_qubits::Integer)
-    po = pauli_operators(num_qubits)
+    num_qubits > 0 || throw(ArgumentError("Number of qubits must be positive."))
+
+    basis = SpinBasis(1//2)
+    paulis = (
+        identityoperator(SparseOpType, ComplexF64, basis).data,
+        sigmax(basis).data,
+        sigmay(basis).data,
+        sigmaz(basis).data,
+    )
     sop_dim = 4 ^ num_qubits
-    return mapreduce(x -> sparse(reshape(x.data, sop_dim)), (x, y) -> [x y], po)
+    columns = Vector{SparseVector{ComplexF64,Int}}(undef, sop_dim)
+    for column in eachindex(columns)
+        code = column - 1
+        data = paulis[mod(code, 4) + 1]
+        code = div(code, 4)
+        for _ in 2:num_qubits
+            data = kron(paulis[mod(code, 4) + 1], data)
+            code = div(code, 4)
+        end
+        columns[column] = sparse(reshape(data, sop_dim))
+    end
+    return reduce(hcat, columns)
 end
 
 """

--- a/src/time_dependent_operator.jl
+++ b/src/time_dependent_operator.jl
@@ -136,12 +136,12 @@ function TimeDependentSum(coeffs::C, operators::O; init_time::T=0.0)  where {C<:
     TimeDependentSum(Tf, coeffs, operators; init_time)
 end
 
-function TimeDependentSum(::Type{Tf}, args::Vararg{Pair}; init_time::T=0.0) where {Tf<:Number,T<:Number}
+function TimeDependentSum(::Type{Tf}, args::Vararg{Pair,N}; init_time::T=0.0) where {Tf<:Number,T<:Number,N}
     cs, ops = zip(args...)
     TimeDependentSum(Tf, [cs...], [ops...]; init_time)
 end
 
-function TimeDependentSum(args::Vararg{Pair}; init_time::T=0.0) where {T<:Number}
+function TimeDependentSum(args::Vararg{Pair,N}; init_time::T=0.0) where {T<:Number,N}
     cs, _ = zip(args...)
     Tf = mapreduce(typeof, promote_type, eval_coefficients(cs, init_time))
     TimeDependentSum(Tf, args...; init_time)

--- a/test/test_pauli.jl
+++ b/test/test_pauli.jl
@@ -32,8 +32,12 @@ CZ_ptm = PauliTransferMatrix(CZ_sop)
 # Test construction of non-symmetric unitary.
 CNOT = DenseOperator(q2, q2, diagm(0 => [1,1,0,0], 1 => [0,0,1], -1 => [0,0,1]))
 CNOT_sop = SuperOperator(CNOT)
-CNOT_chi = ChiMatrix(CNOT)
-CNOT_ptm = PauliTransferMatrix(CNOT)
+CNOT_chi = @inferred ChiMatrix(CNOT)
+CNOT_ptm = @inferred PauliTransferMatrix(CNOT)
+
+pauli_vectors = @inferred QuantumOpticsBase.pauli_basis_vectors(2)
+@test pauli_vectors' * pauli_vectors ≈ 4I
+@test_throws ArgumentError QuantumOpticsBase.pauli_basis_vectors(0)
 
 @test CNOT_sop.basis_l == CNOT_sop.basis_r == (q2, q2)
 @test CNOT_chi.basis_l == CNOT_chi.basis_r == (q2, q2)

--- a/test/test_time_dependent_operators.jl
+++ b/test/test_time_dependent_operators.jl
@@ -130,7 +130,7 @@ end
         @test (@allocated set_time!(o_t_tup, t)) == 0
     end
 
-    o_t2 = TimeDependentSum(f1=>a, f2=>n)
+    o_t2 = @inferred TimeDependentSum(f1=>a, f2=>n)
     @test o_t(t) == o_t2(t)
 
     o_t_ = dense(o_t)


### PR DESCRIPTION
## Summary

- generate Pauli basis vectors through concretely typed sparse columns instead of the heterogeneous `pauli_operators` path
- specialize `TimeDependentSum(pair...)` constructors on the number of pairs while preserving their vector-backed storage and equality behavior
- add inference, orthogonality, and invalid-input coverage

## SnoopCompile findings

Each workload was captured in a fresh process with only `SnoopCompileCore` loaded before `@snoop_inference`. The full analysis package was loaded afterward to inspect `inference_triggers`, group roots by source, filter package-owned methods, and run `parcel`.

On Julia 1.10, the canonical Pauli workload changed from 87 inference triggers and 3 QuantumOpticsBase-owned method groups to 2 Base-owned triggers and no QuantumOpticsBase-owned groups. The pair-based time-dependent workload changed from 4 triggers, including one package-owned group, to no triggers.

These were structural inference problems, so this PR does not add manual precompile directives or a SnoopCompile dependency.

## Cold-start benchmark

Reportable comparison on Julia 1.12.6 with 5 cache builds and 4 samples per build:

| Scenario | Metric | Base | PR | Change |
|---|---:|---:|---:|---:|
| Pauli | First task | 2072.96 ms | 1185.48 ms | -42.81% |
| Pauli | Total cold latency | 2784.27 ms | 1833.70 ms | -34.14% |
| Pauli | Warm task | 0.293 ms | 0.113 ms | -61.44% |
| Fock control | Total cold latency | 788.19 ms | 820.06 ms | +4.04% |
| Composite control | Total cold latency | 885.14 ms | 874.11 ms | -1.25% |
| Package cache | Size | 21.87 MiB | 21.87 MiB | unchanged |

The Pauli total improved materially in all 5 paired builds. Neither control had a material per-build regression. Aggregate cache-build medians were 9.83 s for the base and 10.48 s for this branch; paired build deltas had mixed signs.

Command:

```sh
QOB_PRECOMPILE_BUILDS=5 \
QOB_PRECOMPILE_SAMPLES=4 \
QOB_PRECOMPILE_SCENARIOS=fock,composite,pauli \
benchmark/precompile/run.sh RESULTS base=BASE_CHECKOUT head=PR_CHECKOUT
```

## Validation

- Julia 1.10.12: `Pkg.test()` — 2132 passed, 2 pre-existing broken
- Julia 1.12.6: `Pkg.test()` — 2132 passed, 2 pre-existing broken
- Julia 1.12.6: `JET_TEST=true Pkg.test()` — package-wide JET test passed
- independent review verified exact Pauli basis equality and sparse matrix type for 1 through 4 qubits on Julia 1.10 and 1.12

Optional CUDA, AMDGPU, and OpenCL tests were not run.

## Follow-up targets

Direct `pauli_operators` consumers in alternate Chi/superoperator conversions and non-contiguous multi-index `embed` remain worthwhile but require broader, separately reviewable changes.
