### PR TITLE
Make multi-index Operator embedding inferable

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -3,9 +3,7 @@ name: Cold-start latency
 on:
   pull_request:
     paths:
-      - src/QuantumOpticsBase.jl
-      - src/precompile.jl
-      - src/precompile_statements.jl
+      - src/**
       - benchmark/precompile/**
       - .github/workflows/precompile.yml
       - Project.toml
@@ -48,6 +46,7 @@ jobs:
           QOB_PRECOMPILE_BUILDS: '2'
           QOB_PRECOMPILE_SAMPLES: '5'
           QOB_PRECOMPILE_SCENARIOS: fock,composite
+          QOB_PRECOMPILE_EXTRA_SCENARIOS: head=embed_noncontiguous
         run: |
           head/benchmark/precompile/run.sh \
             cold-start-results \

--- a/benchmark/precompile/README.md
+++ b/benchmark/precompile/README.md
@@ -59,7 +59,9 @@ Use five cache builds and four recorded samples for reportable candidate
 measurements. The default of one build and two samples is intended only for
 smoke tests. Supported scenarios are `fock`, `composite`, `particle`,
 `manybody`, `superoperator`, `metrics`, `nlevel`, `charge`,
-`time_dependent`, and `pauli`.
+`time_dependent`, `pauli`, and `embed_noncontiguous`. The
+`embed_noncontiguous` scenario embeds a joint operator into the first and third
+of four heterogeneous subsystems.
 
 For a multi-candidate experiment, use `QOB_PRECOMPILE_EXTRA_SCENARIOS` to run a
 motivating scenario only for its named variant and for the baseline. This keeps

--- a/benchmark/precompile/scenarios.jl
+++ b/benchmark/precompile/scenarios.jl
@@ -46,6 +46,25 @@ function composite()
     return norm(derivative)
 end
 
+function embed_noncontiguous()
+    nlevel_basis = NLevelBasis(3)
+    spin_basis = SpinBasis(1 // 2)
+    fock_basis = FockBasis(4)
+    auxiliary_basis = GenericBasis(2)
+    basis = nlevel_basis ⊗ spin_basis ⊗ fock_basis ⊗ auxiliary_basis
+
+    nlevel_operator = dense(paulix(nlevel_basis))
+    fock_operator = dense(number(fock_basis))
+    selected_operator = nlevel_operator ⊗ fock_operator
+    embedded = embed(basis, [1, 3], selected_operator)
+    expected =
+        nlevel_operator ⊗ identityoperator(spin_basis) ⊗
+        fock_operator ⊗ identityoperator(auxiliary_basis)
+
+    check(embedded == expected, "noncontiguous embedding returned the wrong operator")
+    return length(embedded.data.nzval)
+end
+
 function particle()
     position_basis = PositionBasis(-10, 10, 200)
     momentum_basis = MomentumBasis(position_basis)
@@ -171,6 +190,7 @@ end
 const SCENARIOS = Dict(
     "fock" => fock,
     "composite" => composite,
+    "embed_noncontiguous" => embed_noncontiguous,
     "particle" => particle,
     "manybody" => manybody,
     "superoperator" => superoperator,

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -23,6 +23,13 @@ Embed operator acting on a joint Hilbert space where missing indices are filled 
 """
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
                indices, op::T) where T<:DataOperator
+    _embed_dataoperator(basis_l, basis_r, indices, op)
+end
+
+# Compatibility fallback for downstream DataOperator subtypes and unsupported
+# Operator storage. Keep reconstruction through the downstream type wrapper.
+function _embed_dataoperator(basis_l::CompositeBasis, basis_r::CompositeBasis,
+                             indices, op::T) where T<:DataOperator
     N = length(basis_l.bases)
     @assert length(basis_r.bases) == N
 

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -84,6 +84,10 @@ function _embed_strides(dimensions::Vector{Int})
     return strides, total
 end
 
+# Map column-major coordinates for a subsystem subset to zero-based offsets in
+# the full tensor product. Keeping `indices` in caller order handles reordered
+# embeddings. A final matrix coordinate is a selected-operator offset plus the
+# corresponding offset for the omitted identity subsystems.
 function _embed_offsets(dimensions::Vector{Int}, strides::Vector{Int}, indices::Vector{Int})
     offsets = Vector{Int}(undef, prod(dimensions))
     for linear_index in eachindex(offsets)

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -72,6 +72,92 @@ const EyeOpPureType{BL,BR} = Operator{BL,BR,<:Eye}
 const EyeOpAdjType{BL,BR} = Operator{BL,BR,<:Adjoint{<:Number,<:Eye}}
 const EyeOpType{BL,BR} = Union{EyeOpPureType{BL,BR},EyeOpAdjType{BL,BR}}
 
+const _EmbedOpType{BL,BR} = Union{DenseOpType{BL,BR},SparseOpType{BL,BR},EyeOpType{BL,BR}}
+
+function _embed_strides(dimensions::Vector{Int})
+    strides = Vector{Int}(undef, length(dimensions))
+    total = 1
+    for i in eachindex(dimensions)
+        strides[i] = total
+        total *= dimensions[i]
+    end
+    return strides, total
+end
+
+function _embed_offsets(dimensions::Vector{Int}, strides::Vector{Int}, indices::Vector{Int})
+    offsets = Vector{Int}(undef, prod(dimensions))
+    for linear_index in eachindex(offsets)
+        coordinate = linear_index - 1
+        offset = 0
+        for i in eachindex(indices)
+            coordinate, digit = divrem(coordinate, dimensions[i])
+            offset += digit * strides[indices[i]]
+        end
+        offsets[linear_index] = offset
+    end
+    return offsets
+end
+
+function _embed_basis_match(
+    full::CompositeBasis, indices::Vector{Int}, selected::B
+) where B<:Basis
+    candidate = reduced(full, indices)
+    candidate isa B && return (candidate::B) == selected
+    return (candidate == selected)::Bool
+end
+
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
+               indices::AbstractVector{<:Integer}, op::T) where T<:_EmbedOpType
+    N = length(basis_l.bases)
+    @assert length(basis_r.bases) == N
+    check_indices(N, indices)
+
+    indices_int = Int[index for index in indices]
+    _embed_basis_match(basis_l, indices_int, op.basis_l) || throw(IncompatibleBases())
+    _embed_basis_match(basis_r, indices_int, op.basis_r) || throw(IncompatibleBases())
+
+    dimensions_l = Int[dimension for dimension in basis_l.shape]
+    dimensions_r = Int[dimension for dimension in basis_r.shape]
+    strides_l, total_l = _embed_strides(dimensions_l)
+    strides_r, total_r = _embed_strides(dimensions_r)
+
+    selected = falses(N)
+    for index in indices_int
+        selected[index] = true
+    end
+    complement_indices = Int[index for index in 1:N if !selected[index]]
+
+    selected_rows = _embed_offsets(dimensions_l[indices_int], strides_l, indices_int)
+    selected_columns = _embed_offsets(dimensions_r[indices_int], strides_r, indices_int)
+    identity_dimensions = min.(dimensions_l[complement_indices], dimensions_r[complement_indices])
+    identity_rows = _embed_offsets(identity_dimensions, strides_l, complement_indices)
+    identity_columns = _embed_offsets(identity_dimensions, strides_r, complement_indices)
+
+    data = SparseMatrixCSC{eltype(op),Int}(op.data)
+    entry_count = count(!iszero, data.nzval) * length(identity_rows)
+    rows = Vector{Int}(undef, entry_count)
+    columns = Vector{Int}(undef, entry_count)
+    values = Vector{eltype(op)}(undef, entry_count)
+
+    entry = 1
+    for column in axes(data, 2)
+        for position in nzrange(data, column)
+            value = data.nzval[position]
+            iszero(value) && continue
+            row_offset = selected_rows[data.rowval[position]]
+            column_offset = selected_columns[column]
+            for identity_index in eachindex(identity_rows)
+                rows[entry] = row_offset + identity_rows[identity_index] + 1
+                columns[entry] = column_offset + identity_columns[identity_index] + 1
+                values[entry] = value
+                entry += 1
+            end
+        end
+    end
+
+    return Operator(basis_l, basis_r, sparse(rows, columns, values, total_l, total_r))
+end
+
 identityoperator(::Type{T}, ::Type{S}, b1::Basis, b2::Basis) where {T<:DataOperator,S<:Number} =
     Operator(b1, b2, Eye{S}(length(b1), length(b2)))
 identityoperator(::Type{T}, ::Type{S}, b::Basis) where {T<:DataOperator,S<:Number} =

--- a/test/test_embed.jl
+++ b/test/test_embed.jl
@@ -3,6 +3,23 @@ using Test
 using QuantumOpticsBase
 using Random, SparseArrays, LinearAlgebra
 
+struct EmbedFallbackOperator{BL,BR,T} <: DataOperator{BL,BR}
+    basis_l::BL
+    basis_r::BR
+    data::T
+end
+Base.eltype(op::EmbedFallbackOperator) = eltype(op.data)
+
+struct EmbedEquivalentBasisA <: Basis
+    shape::Vector{Int}
+end
+struct EmbedEquivalentBasisB <: Basis
+    shape::Vector{Int}
+end
+Base.:(==)(left::EmbedEquivalentBasisA, right::EmbedEquivalentBasisB) =
+    left.shape == right.shape
+Base.:(==)(left::EmbedEquivalentBasisB, right::EmbedEquivalentBasisA) = right == left
+
 @testset "embed" begin
 
 Random.seed!(0)
@@ -71,6 +88,137 @@ y = op1 ⊗ I2 ⊗ op3
 x = embed(b, Dict([3,1] => op3⊗op1))
 y = op1 ⊗ I2 ⊗ op3
 @test 0 ≈ abs(tracedistance_nh(x, y))
+
+@testset "inferred multi-index embedding" begin
+    b1 = NLevelBasis(2)
+    b2 = SpinBasis(1 // 2)
+    b3 = FockBasis(2)
+    b4 = GenericBasis(2)
+    full_basis = b1 ⊗ b2 ⊗ b3 ⊗ b4
+
+    op1_real = DenseOperator(b1, reshape(Float64.(1:4), 2, 2))
+    op2_real = DenseOperator(b2, reshape(Float64.(1:4), 2, 2))
+    op3_real = DenseOperator(b3, reshape(Float64.(1:9), 3, 3))
+    op4_real = DenseOperator(b4, reshape(Float64.(1:4), 2, 2))
+    op1_complex = DenseOperator(b1, (1 + 2im) .* op1_real.data)
+    op3_complex = DenseOperator(b3, (2 - 1im) .* op3_real.data)
+
+    expected_real = op1_real ⊗ identityoperator(b2) ⊗ op3_real ⊗ identityoperator(b4)
+    selected_real = op1_real ⊗ op3_real
+    indices = [1, 3]
+    selected_data = copy(selected_real.data)
+    embedded_real = @inferred embed(full_basis, indices, selected_real)
+    @test embedded_real == expected_real
+    @test embedded_real.data isa SparseMatrixCSC{Float64,Int}
+    @test embedded_real.basis_l === full_basis
+    @test embedded_real.basis_r === full_basis
+    @test indices == [1, 3]
+    @test selected_real.data == selected_data
+
+    selected_complex = op1_complex ⊗ op3_complex
+    expected_complex = op1_complex ⊗ identityoperator(b2) ⊗ op3_complex ⊗ identityoperator(b4)
+    @test (@inferred embed(full_basis, [1, 3], selected_complex)) == expected_complex
+    @test (@inferred embed(full_basis, [1, 3], sparse(selected_real))) == expected_real
+    @test (@inferred embed(full_basis, [1, 3], sparse(selected_complex))) == expected_complex
+
+    dense_adjoint = dagger(selected_complex)
+    sparse_adjoint = dagger(sparse(selected_complex))
+    expected_adjoint =
+        dagger(op1_complex) ⊗ identityoperator(b2) ⊗ dagger(op3_complex) ⊗ identityoperator(b4)
+    @test (@inferred embed(full_basis, [1, 3], dense_adjoint)) == expected_adjoint
+    @test (@inferred embed(full_basis, [1, 3], sparse_adjoint)) == expected_adjoint
+
+    selected_identity = identityoperator(b1 ⊗ b3)
+    @test (@inferred embed(full_basis, [1, 3], selected_identity)) == identityoperator(full_basis)
+
+    selected_reordered = op3_complex ⊗ op1_complex
+    @test (@inferred embed(full_basis, [3, 1], selected_reordered)) == expected_complex
+
+    expected_contiguous =
+        identityoperator(b1) ⊗ op2_real ⊗ op3_real ⊗ identityoperator(b4)
+    @test (@inferred embed(full_basis, [2, 3], op2_real ⊗ op3_real)) == expected_contiguous
+
+    selected_permutation = op4_real ⊗ op2_real ⊗ op1_real ⊗ op3_real
+    expected_permutation = op1_real ⊗ op2_real ⊗ op3_real ⊗ op4_real
+    @test (@inferred embed(full_basis, [4, 2, 1, 3], selected_permutation)) == expected_permutation
+
+    vector_result = @inferred embed(full_basis, [2], op2_real)
+    integer_result = @inferred embed(full_basis, 2, op2_real)
+    @test vector_result == integer_result
+
+    @test_throws QuantumOpticsBase.IncompatibleBases embed(
+        full_basis, [1, 3], op1_real ⊗ op2_real
+    )
+    @test_throws ArgumentError embed(full_basis, [1, 1], op1_real ⊗ op1_real)
+    @test_throws ArgumentError embed(full_basis, [1, 5], op1_real ⊗ op1_real)
+    @test_throws AssertionError embed(full_basis, b1 ⊗ b2 ⊗ b3, [1], op1_real)
+end
+
+@testset "rectangular multi-index embedding" begin
+    dimensions_l = (2, 3, 4, 2)
+    dimensions_r = (3, 2, 2, 4)
+    bases_l = GenericBasis.(dimensions_l)
+    bases_r = GenericBasis.(dimensions_r)
+    basis_l = reduce(⊗, bases_l)
+    basis_r = reduce(⊗, bases_r)
+
+    op1 = DenseOperator(
+        bases_l[1], bases_r[1], reshape(ComplexF64.(1:6), dimensions_l[1], dimensions_r[1])
+    )
+    op3 = DenseOperator(
+        bases_l[3], bases_r[3], reshape(ComplexF64.(1:8), dimensions_l[3], dimensions_r[3])
+    )
+    selected = op1 ⊗ op3
+    expected =
+        op1 ⊗ identityoperator(bases_l[2], bases_r[2]) ⊗
+        op3 ⊗ identityoperator(bases_l[4], bases_r[4])
+
+    embedded = @inferred embed(basis_l, basis_r, [1, 3], selected)
+    @test embedded == expected
+    @test embedded.data isa SparseMatrixCSC{ComplexF64,Int}
+end
+
+@testset "DataOperator compatibility fallback" begin
+    b1 = GenericBasis(2)
+    b2 = GenericBasis(3)
+    basis = b1 ⊗ b2
+    selected_basis = b2 ⊗ b1
+    data = reshape(ComplexF64.(1:36), 6, 6)
+    custom = EmbedFallbackOperator(selected_basis, selected_basis, data)
+
+    embedded = embed(basis, [2, 1], custom)
+    reference = embed(basis, [2, 1], Operator(selected_basis, data))
+    @test embedded isa EmbedFallbackOperator
+    @test embedded.basis_l === basis
+    @test embedded.basis_r === basis
+    @test embedded.data == reference.data
+    @test custom.data == data
+
+    b3 = GenericBasis(2)
+    full_basis = b1 ⊗ b2 ⊗ b3
+    selected_basis = b1 ⊗ b3
+    diagonal1 = Operator(b1, Diagonal([1.0, 2.0]))
+    diagonal3 = Operator(b3, Diagonal([3.0, 4.0]))
+    diagonal_operator = diagonal1 ⊗ diagonal3
+    diagonal_data = diagonal_operator.data
+    @test diagonal_data isa Diagonal
+    @test embed(full_basis, [1, 3], diagonal_operator) ==
+          diagonal1 ⊗ identityoperator(b2) ⊗ diagonal3
+    @test diagonal_operator.data === diagonal_data
+end
+
+@testset "cross-type basis compatibility" begin
+    basis_a = EmbedEquivalentBasisA([2])
+    basis_b = EmbedEquivalentBasisB([2])
+    gap_basis = GenericBasis(3)
+    full_basis = basis_a ⊗ gap_basis
+    data = [1.0 2.0; 3.0 4.0]
+    selected = DenseOperator(basis_b, data)
+
+    embedded = @inferred embed(full_basis, [1], selected)
+    expected = DenseOperator(basis_a, data) ⊗ identityoperator(gap_basis)
+    @test embedded == expected
+end
 
 end # testset
 end


### PR DESCRIPTION
## Summary

- add an `Operator`-specific multi-index `embed` path that assembles CSC coordinates directly
- preserve the generic `DataOperator` implementation as the compatibility fallback for downstream wrappers and unsupported storage
- fix one-element vector embeddings and rectangular embeddings with multiple omitted subsystems
- add inference-focused coverage and a self-checking `embed_noncontiguous` cold-start scenario
- broaden the cold-start workflow filter from selected source files to `src/**`

The optimized path covers CPU `Matrix`, `SparseMatrixCSC`, supported adjoints, and `Eye` data. It preserves the full left/right basis objects, caller index order, input data, and `SparseMatrixCSC{eltype(op),Int}` output.

## Correctness

An independent coordinate check used four rectangular subsystems, both `[1,3]` and `[3,1]`, and dense and sparse inputs.

| Check | `master` (`0e908d6`) | This PR |
|---|---:|---:|
| rectangular result error norm | 389.995 | 0 |
| rectangular maximum error | 48 | 0 |
| `embed(..., [1], op)` versus integer overload | error norm 33.045 | equal, error norm 0 |

Tests also cover real and complex storage, dense and sparse data, adjoints, `Eye`, contiguous and full permutations, several omitted subsystems, errors, no mutation, exotic `Operator` storage, a downstream-style `DataOperator`, and cross-concrete-type basis equality.

## Inference

Inputs were constructed before `@snoop_inference`. The trace was analyzed with `accumulate_by_source`, `filtermod(QuantumOpticsBase)`, and `parcel`, following the SnoopCompile inference workflow.

Julia 1.10.12:

| Workload | `@inferred` | QOB trigger groups | QOB direct triggers | QOB parcel |
|---|---|---:|---:|---:|
| dense `[1,3]`, base | fail | 1 | 9 | 111.870 ms / 7 MIs |
| dense `[1,3]`, PR | pass | 0 | 0 | 24.029 ms / 1 MI |
| sparse `[3,1]`, base | fail | 1 | 9 | 197.269 ms / 7 MIs |
| sparse `[3,1]`, PR | pass | 0 | 0 | 14.880 ms / 1 MI |

Julia 1.12.6 also passes `@inferred` with zero actionable trigger groups, direct triggers, or stale instances. Each 1.12 trace has three known missing-backtrace roots, so its parcel total is incomplete and is not compared.

The candidate environment was copied from the baseline and retargeted only with `Pkg.develop`. Projects are byte-identical, and Manifests are byte-identical after normalizing the QuantumOpticsBase path (SHA-256 `3995b57f9543ab7571f0386e4b3fd1f296bde005e5e261e5dc0de59f0cbd21cd`).

## Warm measurements

Julia 1.10.12, one Julia/BLAS/OpenMP thread, one pinned core, five adjacent counterbalanced baseline/candidate trials. Values are medians of trial medians.

| Workload | Runtime | Runtime delta | Bytes | Byte delta | Allocations |
|---|---:|---:|---:|---:|---:|
| dense `[1,3]` | 11.616 -> 3.855 us | -66.81% | 59,296 -> 23,152 | -60.96% | 130 -> 51 |
| dense `[3,1]` | 11.565 -> 3.850 us | -66.71% | 59,296 -> 23,152 | -60.96% | 130 -> 51 |
| sparse `[1,3]` | 12.050 -> 1.490 us | -87.63% | 38,080 -> 10,912 | -71.34% | 147 -> 51 |
| sparse `[3,1]` | 12.190 -> 1.480 us | -87.86% | 38,080 -> 10,912 | -71.34% | 147 -> 51 |

All 20 paired runtime comparisons improve by at least 65.22%.

## Cold-start measurements

Julia 1.12.6, five cache builds, four samples per build, with `fock` and `composite` controls:

| Metric | Base | PR | Delta |
|---|---:|---:|---:|
| `embed_noncontiguous` total | 1673.851 ms | 1284.790 ms | -389.062 ms (-23.24%) |
| aggregate controls | 1494.708 ms | 1494.262 ms | -0.446 ms (-0.03%) |
| cache size | 21.8679 MiB | 21.8896 MiB | +0.0217 MiB (+0.10%) |
| cache build | 8.9598 s | 8.9141 s | -0.0457 s (-0.51%) |

The target materially improves in 5/5 paired builds. No cache build is more than 10% slower.

## Validation

- focused Julia 1.10.12 embed tests: 42/42 pass
- `embed_noncontiguous` self-check: pass
- full `Pkg.test()` Julia 1.10.12: 2,163 pass, 2 expected broken
- full `Pkg.test()` Julia 1.12.6: 2,163 pass, 2 expected broken
- Aqua and doctests: pass in both full suites
- `JET_TEST=true` Julia 1.10.12: 1/1 pass
- documentation build Julia 1.12.6: pass
- independent implementation review: no blockers

JET 0.10.6 on Julia 1.12.6 fails inside JET before package analysis with `Expected MethodTableView`; the supported Julia 1.10 JET run passes. Platform, downgrade, and downstream checks are left to hosted CI.

## Residual risks

- exotic/non-CSC `Operator` storage intentionally uses the legacy fallback
- generic downstream `DataOperator` behavior is unchanged and remains outside the optimized path
- this changes no exported API and adds no dependency or manual precompile directive
