### PR TITLE
Test closure boxes on Julia 1.14+

### DIFF
--- a/test/test_closure_boxes.jl
+++ b/test/test_closure_boxes.jl
@@ -1,0 +1,8 @@
+@testitem "test_closure_boxes" begin
+using QuantumOpticsBase
+using Test
+
+if VERSION >= v"1.14"
+    @test isempty(Test.detect_closure_boxes(QuantumOpticsBase))
+end
+end


### PR DESCRIPTION
## Summary

- add a normal TestItemRunner item for `Test.detect_closure_boxes(QuantumOpticsBase)`
- guard the assertion with `VERSION >= v"1.14"`
- leave the existing CI workflow and version matrix unchanged

## Audit result

Julia `1.14.0-DEV.3007` reports no closure boxes in either `QuantumOpticsBase` or `QuantumOpticsBaseMakieExt`. A positive control reports the expected `Core.Box`, and the scan also succeeds with compiled modules disabled. Because there are no findings, this PR does not add artificial `let` wrappers; the test preserves the verified zero-box invariant once CI reaches Julia 1.14 stable.

The version comparison intentionally skips 1.14 prereleases, which sort below `v"1.14"`.

## Validation

- hosted PR checks: 8 passed, including Julia 1.10, all current-Julia platforms, downgrade, docs, and coverage
- Julia 1.12 full `Pkg.test`: 2,213 passed, 2 expected broken
- Julia 1.10 and 1.12: guarded branch parses and skips cleanly
- Julia 1.14 nightly: direct detector assertion passes with zero findings
- `git diff --check`
- independent final review: no findings
