### PR TITLE
Preserve tuple inference in TimeDependentSum pair constructors

### DIFF
--- a/src/time_dependent_operator.jl
+++ b/src/time_dependent_operator.jl
@@ -138,7 +138,7 @@ end
 
 function TimeDependentSum(::Type{Tf}, args::Vararg{Pair,N}; init_time::T=0.0) where {Tf<:Number,T<:Number,N}
     cs, ops = zip(args...)
-    TimeDependentSum(Tf, [cs...], [ops...]; init_time)
+    TimeDependentSum(Tf, cs, ops; init_time)
 end
 
 function TimeDependentSum(args::Vararg{Pair,N}; init_time::T=0.0) where {T<:Number,N}

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -1,0 +1,15 @@
+@testitem "JET optimization: TimeDependentSum pairs" tags = [:jet] begin
+using JET
+using QuantumOpticsBase
+using Test
+
+basis = SpinBasis(1 // 2)
+sx = sigmax(basis)
+sz = sigmaz(basis)
+
+JET.@test_opt target_modules=(QuantumOpticsBase,) TimeDependentSum(cos => sx, sin => sz)
+
+operator = TimeDependentSum(cos => sx, sin => sz)
+@test QuantumOpticsBase.coefficients(operator) == (cos, sin)
+JET.@test_opt target_modules=(QuantumOpticsBase,) set_time!(operator, 0.25)
+end

--- a/test/test_time_dependent_operators.jl
+++ b/test/test_time_dependent_operators.jl
@@ -131,7 +131,8 @@ end
     end
 
     o_t2 = @inferred TimeDependentSum(f1=>a, f2=>n)
-    @test o_t(t) == o_t2(t)
+    @test QOB.coefficients(o_t2) == (f1, f2)
+    @test dense(QOB.static_operator(o_t(t))) == dense(QOB.static_operator(o_t2(t)))
 
     o_t_ = dense(o_t)
     @test all(isa(o, DenseOpType) for o in QOB.suboperators(o_t_))


### PR DESCRIPTION
## Summary

- preserve the coefficient and operator tuples already produced by the pair constructor
- remove abstract `Vector{Function}` dispatch from pair construction and `set_time!`
- add focused JET optimization regression coverage and align the ordinary representation test

The constructor signatures are unchanged. Pair-based construction now stores tuple-backed coefficients and suboperators. In particular, `QuantumOpticsBase.coefficients(op)` returns a tuple for this construction form, so an otherwise equivalent vector-built `TimeDependentSum` is no longer structurally equal. Vector-based construction is unchanged.

## JET optimization analysis

Measured on Julia 1.12.6 with JET 0.12.1 and `target_modules=(QuantumOpticsBase,)`:

| Call | Base | This PR |
|---|---:|---:|
| `TimeDependentSum(cos => sx, sin => sz)` | 2 findings | 0 |
| `set_time!(operator, 0.25)` | 2 findings | 0 |

The base findings were runtime dispatch through `c::Function(t)::Any` and the following `Float64(::Any)` conversion. The new `JET.@test_opt` checks assert the concrete pair-construction and update paths without depending on report counts.

## Warm benchmark

One thread, 10,000 samples, warmed calls, same Julia and machine:

| Call | Base median | PR median | Allocations |
|---|---:|---:|---:|
| Constructor | 163.410 ns, 544 B | 22.299 ns, 240 B | 14 → 4 |
| `set_time!` | 150 ns, 64 B | 30 ns, 0 B | 4 → 0 |

These are steady-state microbenchmarks, not full cold-start latency measurements.

## Validation

- `time_dependent()` precompile scenario wrapper: passed all guards
- `JET_TEST=true JULIA_NUM_THREADS=2 julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`: 4/4 passed
- `JULIA_NUM_THREADS=4 julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`: 2,214 passed, 2 existing expected broken
- independent advanced review: no blocking findings; explicit-`Tf`, `init_time`, one-pair, copy, nested update, and numerical edge checks passed
- `git diff --check`: passed

Julia 1.10 and optional GPU backends were not run locally. The hosted compatibility, cold-start, GitHub, and Buildkite checks are expected to cover the remaining environments.

## PR series

Merge order:

1. `codex/time-dependent-pair-inference` (this PR)
2. `codex/lazyproduct-constructor-inference`
3. `codex/ptranspose-inference`

Later branches will be rebased after preceding PRs merge so their independent additions to `test/jet_opt_tests.jl` are retained.
