### PR TITLE
Make heterogeneous LazyProduct construction inferable

### DIFF
--- a/src/operators_lazyproduct.jl
+++ b/src/operators_lazyproduct.jl
@@ -19,17 +19,15 @@ mutable struct LazyProduct{BL,BR,F,T,KTL,BTR} <: LazyOperator{BL,BR}
     ket_l::KTL
     bra_r::BTR
     function LazyProduct{BL,BR,F,T,KTL,BTR}(operators::T, ket_l::KTL, bra_r::BTR, factor::F=1) where {BL,BR,F,T,KTL,BTR}
-        for i = 2:length(operators)
-            check_multiplicable(operators[i-1], operators[i])
-        end
+        foreach(check_multiplicable, Base.front(operators), Base.tail(operators))
         new(operators[1].basis_l, operators[end].basis_r, factor, operators,ket_l,bra_r)
     end
 end
 function LazyProduct(operators::T, factor::F=1) where {T,F}
     BL = typeof(operators[1].basis_l)
     BR = typeof(operators[end].basis_r)
-    ket_l=Tuple(Ket(operators[i].basis_l) for i in 2:length(operators))
-    bra_r=Tuple(Bra(operators[i].basis_r) for i in 1:length(operators)-1)
+    ket_l=map(operator -> Ket(operator.basis_l), Base.tail(operators))
+    bra_r=map(operator -> Bra(operator.basis_r), Base.front(operators))
     KTL = typeof(ket_l)
     BTR = typeof(bra_r)
     LazyProduct{BL,BR,F,T,KTL,BTR}(operators, ket_l, bra_r, factor)

--- a/src/operators_lazyproduct.jl
+++ b/src/operators_lazyproduct.jl
@@ -1,6 +1,25 @@
 import Base: isequal, ==, *, /, +, -
 import Adapt
 
+function _lazyproduct_check_multiplicable(operators)
+    for i = 2:length(operators)
+        check_multiplicable(operators[i-1], operators[i])
+    end
+end
+_lazyproduct_check_multiplicable(operators::Tuple) =
+    foreach(check_multiplicable, Base.front(operators), Base.tail(operators))
+
+function _lazyproduct_buffers(operators)
+    ket_l=Tuple(Ket(operators[i].basis_l) for i in 2:length(operators))
+    bra_r=Tuple(Bra(operators[i].basis_r) for i in 1:length(operators)-1)
+    return ket_l, bra_r
+end
+function _lazyproduct_buffers(operators::Tuple)
+    ket_l=map(operator -> Ket(operator.basis_l), Base.tail(operators))
+    bra_r=map(operator -> Bra(operator.basis_r), Base.front(operators))
+    return ket_l, bra_r
+end
+
 """
     LazyProduct(operators[, factor=1])
     LazyProduct(op1, op2...)
@@ -19,15 +38,14 @@ mutable struct LazyProduct{BL,BR,F,T,KTL,BTR} <: LazyOperator{BL,BR}
     ket_l::KTL
     bra_r::BTR
     function LazyProduct{BL,BR,F,T,KTL,BTR}(operators::T, ket_l::KTL, bra_r::BTR, factor::F=1) where {BL,BR,F,T,KTL,BTR}
-        foreach(check_multiplicable, Base.front(operators), Base.tail(operators))
+        _lazyproduct_check_multiplicable(operators)
         new(operators[1].basis_l, operators[end].basis_r, factor, operators,ket_l,bra_r)
     end
 end
 function LazyProduct(operators::T, factor::F=1) where {T,F}
     BL = typeof(operators[1].basis_l)
     BR = typeof(operators[end].basis_r)
-    ket_l=map(operator -> Ket(operator.basis_l), Base.tail(operators))
-    bra_r=map(operator -> Bra(operator.basis_r), Base.front(operators))
+    ket_l, bra_r = _lazyproduct_buffers(operators)
     KTL = typeof(ket_l)
     BTR = typeof(bra_r)
     LazyProduct{BL,BR,F,T,KTL,BTR}(operators, ket_l, bra_r, factor)

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -13,3 +13,28 @@ operator = TimeDependentSum(cos => sx, sin => sz)
 @test QuantumOpticsBase.coefficients(operator) == (cos, sin)
 JET.@test_opt target_modules=(QuantumOpticsBase,) set_time!(operator, 0.25)
 end
+
+@testitem "LazyProduct constructor inference" tags = [:jet] begin
+using Test
+using QuantumOpticsBase
+using JET
+using LinearAlgebra
+
+basis_1 = SpinBasis(1 // 2)
+basis_2 = FockBasis(1)
+basis_3 = NLevelBasis(2)
+basis_4 = GenericBasis(2)
+data = Matrix{ComplexF64}(I, 2, 2)
+
+operator_1 = DenseOperator(basis_1, basis_2, data)
+operator_2 = DenseOperator(basis_2, basis_3, data)
+operator_3 = DenseOperator(basis_3, basis_4, data)
+operator_4 = DenseOperator(basis_4, basis_1, data)
+
+JET.@test_opt target_modules=(QuantumOpticsBase,) LazyProduct(
+    operator_1,
+    operator_2,
+    operator_3,
+    operator_4,
+)
+end

--- a/test/test_operators_lazyproduct.jl
+++ b/test/test_operators_lazyproduct.jl
@@ -26,6 +26,23 @@ b_r = b1b⊗b2b⊗b3b
 @test_throws QuantumOpticsBase.IncompatibleBases LazyProduct(randoperator(b_l, b_r), randoperator(b_l, b_r))
 @test_throws QuantumOpticsBase.IncompatibleBases LazyProduct(randoperator(b_l, b_r), sparse(randoperator(b_l, b_r)))
 
+# Generic indexed containers retain their storage and behavior.
+operator_lm = randoperator(b_l, b_r)
+operator_ml = randoperator(b_r, b_l)
+operators_any = Any[operator_lm, operator_ml]
+operators_view = @view [operator_lm, operator_ml][:]
+product_any = LazyProduct(operators_any)
+product_view = LazyProduct(operators_view)
+@test product_any.operators === operators_any
+@test product_view.operators === operators_view
+@test dense(product_any) == operator_lm*operator_ml
+@test dense(product_view) == operator_lm*operator_ml
+@test dense(LazyProduct(Any[operator_lm])) == dense(operator_lm)
+
+incompatible_any = Any[operator_lm, operator_lm]
+@test_throws QuantumOpticsBase.IncompatibleBases LazyProduct(incompatible_any)
+@test_throws QuantumOpticsBase.IncompatibleBases LazyProduct(@view incompatible_any[:])
+
 # Test copy
 op1 = 2*LazyProduct(randoperator(b_l, b_r), sparse(randoperator(b_r, b_l)))
 op2 = copy(op1)


### PR DESCRIPTION
## Summary

- construct tuple-input `Ket` and `Bra` caches with tuple-preserving `map` over `Base.tail` and `Base.front`
- validate adjacent tuple operators in order with `foreach(check_multiplicable, ...)`
- retain the original indexed fallback for generic containers, including `Vector{Any}` and views
- add a four-operator, four-concrete-basis JET regression and ordinary compatibility coverage

Documented vector and vararg construction, one-operator products, incompatibility error order, stored generic containers, and numerical behavior are unchanged.

## JET optimization analysis

On Julia 1.12.6 with JET 0.12.1 and `target_modules=(QuantumOpticsBase,)`, the four-operator cycle had one package-owned runtime dispatch in the base constructor because the generated cache tuples left existential `KTL` and `BTR` types. The final tuple-specialized constructor reports zero findings.

A map-only intermediate experiment exposed one remaining indexed `check_multiplicable` dispatch. Tuple-aware `foreach` removes that dispatch. The generic fallback keeps the pre-existing indexed behavior for non-tuple containers.

## Warm benchmark

Four heterogeneous operators, one thread, 10,000 warmed samples:

| Revision | Median | Memory | Allocations |
|---|---:|---:|---:|
| Base | 1.799 μs | 1,824 B | 42 |
| This PR | 126.7 ns | 1,008 B | 21 |

This is a steady-state constructor microbenchmark, not a cold-start latency measurement.

## Validation

- focused tuple/vector/view/one-operator/incompatibility/numerical checks: passed
- `particle()` precompile scenario wrapper: passed all guards
- complete JET-tagged suite: 2/2 passed
- ordinary package suite: 2,220 passed, 2 existing expected broken
- independent advanced review: no blocking findings after the generic-container compatibility regression was identified, fixed, and independently rerun
- `git diff --check`: passed

Julia 1.10 and optional GPU backends were not run locally. The hosted compatibility, cold-start, GitHub, and Buildkite checks are expected to cover the remaining environments.

## PR series

Merge order:

1. #258
2. `codex/lazyproduct-constructor-inference` (this PR)
3. `codex/ptranspose-inference`

This branch will be rebased after #258 merges, retaining both additions to `test/jet_opt_tests.jl`.
