### PR TITLE
Make partial-transpose metrics inferable

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -198,13 +198,18 @@ The `indices` argument can be a single integer or a collection of integers.
 function ptranspose(rho::DenseOpType{B,B}, indices=1) where B<:CompositeBasis
     # adapted from qutip.partial_transpose (https://qutip.org/docs/4.0.2/modules/qutip/partial_transpose.html)
     # works as long as QuantumOptics.jl doesn't change the implementation of `tensor`, i.e. tensor(a,b).data = kron(b.data,a.data)
-    nsys = length(rho.basis_l.shape)
+    nsys = length(rho.basis_l.bases)
     mask = ones(Int, nsys)
     mask[collect(indices)] .+= 1
     pt_dims = reshape(1:2*nsys, (nsys,2)) # indices of the operator viewed as a tensor with 2nsys legs
     pt_idx = [[pt_dims[i,mask[i]] for i = 1 : nsys]; [pt_dims[i,3-mask[i]] for i = 1 : nsys] ] # permute the legs on the subsystem of `indices`
     # reshape the operator data into a 2nsys-legged tensor and shape it back with the legs permuted
-    data = reshape(permutedims(reshape(rho.data, Tuple([rho.basis_l.shape; rho.basis_r.shape])), pt_idx), size(rho.data))
+    shape_l = rho.basis_l.shape
+    shape_r = rho.basis_r.shape
+    tensor_shape = ntuple(2*nsys) do i
+        i <= nsys ? shape_l[i] : shape_r[i-nsys]
+    end
+    data = reshape(permutedims(reshape(rho.data, tensor_shape), pt_idx), size(rho.data))
 
     return DenseOperator(rho.basis_l,data)
     

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -38,3 +38,18 @@ JET.@test_opt target_modules=(QuantumOpticsBase,) LazyProduct(
     operator_4,
 )
 end
+
+@testitem "JET optimization: partial transpose metrics" tags = [:jet] begin
+using Test
+using QuantumOpticsBase
+using JET
+
+basis = SpinBasis(1 // 2)
+up = spinup(basis)
+down = spindown(basis)
+state = (up ⊗ down - down ⊗ up) / sqrt(2)
+rho = dm(state)
+
+JET.@test_opt target_modules=(QuantumOpticsBase,) ptranspose(rho, [1])
+JET.@test_opt target_modules=(QuantumOpticsBase,) negativity(rho, 1)
+end


### PR DESCRIPTION
## Summary

- derive subsystem count from the tuple-backed composite basis
- construct fixed-rank reshape dimensions with `ntuple`, reading left and right shapes separately
- preserve the existing mask, permutation, output basis/type, and numerical behavior
- add Bell-state JET regression coverage for direct `ptranspose` and downstream `negativity`

## JET optimization analysis

Measured on Julia 1.12.6 with JET 0.12.1 and `target_modules=(QuantumOpticsBase,)`:

| Call | Base | This PR |
|---|---:|---:|
| `ptranspose(rho, [1])` | 4 findings | 0 |
| `negativity(rho, 1)` | 7 findings | 0 |

The base findings cascade from dynamic-rank `reshape`/`permutedims` calls into uncertain operator construction and negativity arithmetic. Fixed-rank dimensions remove all package-owned findings for both regression calls.

## Warm benchmark

Bell-state workload, warmed calls:

| Call | Base median | PR median | Allocations |
|---|---:|---:|---:|
| `ptranspose` | 350 ns, 1,488 B | 150 ns, 1,248 B | 28 → 23 |
| `negativity` | 1.51 μs, 5,752 B | 1.13 μs, 5,464 B | 49 → 41 |

These are steady-state microbenchmarks, not full cold-start latency measurements.

## Validation

- focused Bell-state JET item: 2/2 passed
- existing metrics item: 58/58 passed
- `metrics()` precompile scenario wrapper: passed all guards
- complete JET-tagged suite: 3/3 passed
- ordinary package suite: 2,213 passed, 2 existing expected broken
- independent advanced review: no blocking findings; additional nonuniform 2×3×2, scalar/tuple/empty/all-mask, involution, Bell-negativity, and invalid-index checks passed
- `git diff --check`: passed

Julia 1.10 and optional GPU backends were not run locally. The hosted compatibility, cold-start, GitHub, and Buildkite checks are expected to cover the remaining environments.

## Deferred findings

Scalar `ptrace(rho, 1)` still has two package-owned findings: dynamic generated `_ptrace(Val{rank}, ...)` dispatch and downstream `Operator` construction. A consistent fix needs inferable basis reduction coordinated with QuantumInterface across dense, sparse, `Ket`, and `Bra` paths, so it is intentionally deferred.

Lower-priority findings in tuple-backed `LazySum`, `permutesystems`, `LazyTensor`, FFT paths, and downstream entropy calls are also outside this focused series.

## PR series

Merge order:

1. #258
2. #259
3. `codex/ptranspose-inference` (this PR)

This branch will be rebased after #258 and #259 merge, retaining all additions to `test/jet_opt_tests.jl`.
