### PR TITLE
Add JET coverage for fundamental operations.

### DIFF
--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -53,3 +53,114 @@ rho = dm(state)
 JET.@test_opt target_modules=(QuantumOpticsBase,) ptranspose(rho, [1])
 JET.@test_opt target_modules=(QuantumOpticsBase,) negativity(rho, 1)
 end
+
+@testitem "JET optimization: fundamental quantum operations" tags = [:jet] begin
+using Test
+using JET
+using QuantumOpticsBase
+using SparseArrays: sparse
+using LinearAlgebra: mul!
+
+spin_basis = SpinBasis(1 // 2)
+fock_basis = FockBasis(3)
+
+spin_up = basisstate(spin_basis, 1)
+spin_down = basisstate(spin_basis, 2)
+fock_one_photon = basisstate(fock_basis, 2)
+spin_superposition = spin_up + spin_down
+composite_basis = spin_basis ⊗ fock_basis
+composite_state = spin_up ⊗ fock_one_photon
+spin_density = dm(spin_up)
+fock_density = dm(fock_one_photon)
+composite_density = dm(composite_state)
+
+sx_sparse = sigmax(spin_basis)
+sz_sparse = sigmaz(spin_basis)
+sx_dense = dense(sx_sparse)
+sz_dense = dense(sz_sparse)
+fock_number = number(fock_basis)
+spin_identity = identityoperator(spin_basis)
+mul_output = copy(spin_up)
+
+jump_operators = [destroy(fock_basis)]
+fock_liouvillian = liouvillian(fock_number, jump_operators)
+
+@testset "State algebra" begin
+    JET.@test_opt target_modules=(QuantumOpticsBase,) basisstate(spin_basis, 1)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) dagger(spin_up)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) spin_up + spin_down
+    JET.@test_opt target_modules=(QuantumOpticsBase,) normalize(spin_superposition)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) dagger(spin_up) * spin_up
+    JET.@test_opt target_modules=(QuantumOpticsBase,) tensor(spin_up, fock_one_photon)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) dm(spin_up)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) tr(spin_density)
+end
+
+@testset "Operator kernels" begin
+    JET.@test_opt target_modules=(QuantumOpticsBase,) dense(sx_sparse)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sparse(sx_dense)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) dagger(sx_dense)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sx_sparse + sz_sparse
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sx_dense * spin_up
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sx_sparse * spin_up
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sx_dense * sz_sparse
+    JET.@test_opt target_modules=(QuantumOpticsBase,) sx_sparse * sz_dense
+    JET.@test_opt target_modules=(QuantumOpticsBase,) tensor(sx_sparse, fock_number)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) mul!(
+        mul_output, sx_sparse, spin_down, 1.0 + 0im, 0.0 + 0im
+    )
+    JET.@test_opt target_modules=(QuantumOpticsBase,) spin_identity * spin_up
+end
+
+@testset "Observables and composite systems" begin
+    JET.@test_opt target_modules=(QuantumOpticsBase,) expect(sx_dense, spin_up)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) expect(sz_sparse, spin_density)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) variance(sz_sparse, spin_up)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) embed(composite_basis, 1, sx_sparse)
+    JET.@test_opt target_modules=(QuantumOpticsBase,) apply!(
+        copy(composite_state), 1, sx_sparse
+    )
+end
+
+@testset "Open systems" begin
+    JET.@test_opt target_modules=(QuantumOpticsBase,) liouvillian(
+        fock_number, jump_operators
+    )
+    JET.@test_opt target_modules=(QuantumOpticsBase,) fock_liouvillian * fock_density
+end
+
+# These are debt markers, not regression guards or report-count assertions. Each
+# requires at least one package-owned JET finding to remain. An unexpectedly clean
+# result fails so the marker can be promoted to a strict check.
+@testset "Known inference debt" begin
+    @testset "Composite state construction" begin
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true basisstate(
+            composite_basis, [1, 1]
+        )
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true tensor(
+            spin_up, fock_one_photon, spin_down
+        )
+    end
+
+    @testset "Partial trace and indexed expectation" begin
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true ptrace(
+            composite_state, 1
+        )
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true ptrace(
+            composite_density, 1
+        )
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true expect(
+            1, sx_sparse, composite_state
+        )
+    end
+
+    @testset "System permutations" begin
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true permutesystems(
+            composite_state, [2, 1]
+        )
+        JET.@test_opt target_modules=(QuantumOpticsBase,) broken=true permutesystems(
+            composite_density, [2, 1]
+        )
+    end
+end
+end


### PR DESCRIPTION
## Summary

- Add one self-contained `:jet` test item for representative state, operator, composite-system, and open-system workflows.
- Add 26 strict `JET.@test_opt` checks and 7 expected-failure debt markers, all limited with `target_modules=(QuantumOpticsBase,)`.
- Keep this test-only. The existing Buildkite `JET_TEST=true` job already selects all `:jet` items, so no CI configuration changes are needed.

## Coverage

The new item contains 26 strict checks and 7 expected broken checks. It was audited with Julia 1.12.6 and JET 0.12.1.

The strict checks cover state algebra, dense and sparse operator kernels, observable and composite-system operations, and Liouvillian construction and application.

## Expected-failure rationale

- Composite state construction: vector-index `basisstate` and three-argument `tensor` retain inference findings in their coordinate-indexing and variadic reduction paths.
- Partial trace and indexed expectation: `ptrace` for a ket and dense density operator retain inference findings; indexed `expect` reaches the same partial-trace gap.
- System permutations: `permutesystems` for a ket and dense density operator retains inference findings in the subsystem permutation paths.

These use JET native `broken=true` checks. Each marker requires at least one package-owned finding to remain. An unexpectedly clean call fails CI so the marker can be promoted to a strict check. The tests do not assert report counts.

## Validation

- `JET_TEST=true JULIA_NUM_THREADS=2 julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`: passed with 33 passes and 7 expected broken checks across the complete JET suite; the new item contains 26 strict and 7 broken checks.
- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`: passed with 2,221 passes and 2 existing broken tests.
- `git diff --check`: passed.
- Independent advanced review: no findings.