### PR TITLE
Avoid deprecated Vararg type syntax

### DIFF
--- a/src/spinors.jl
+++ b/src/spinors.jl
@@ -130,7 +130,7 @@ Embed a list of operators on subspaces specified by the `indices` into a
 [`SumBasis`](@ref).
 """
 function embed(basis_l::SumBasis, basis_r::SumBasis,
-               indices, ops::Union{Tuple{Vararg{<:DataOperator}},Vector{<:DataOperator}})
+               indices, ops::Union{Tuple{Vararg{DataOperator}},Vector{<:DataOperator}})
     @assert length(basis_r.bases) == length(basis_l.bases)
 
     T = mapreduce(eltype, promote_type, ops)

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -290,7 +290,7 @@ end
 find_basis(a::SuperOperator, rest) = (a.basis_l, a.basis_r)
 
 const BasicMathFunc = Union{typeof(+),typeof(-),typeof(*),typeof(/)}
-function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{Vararg{<:SuperOperator}}, axes)
+function Broadcasted_restrict_f(f::BasicMathFunc, args::Tuple{Vararg{SuperOperator}}, axes)
     args_ = Tuple(a.data for a=args)
     return Broadcast.Broadcasted(f, args_, axes)
 end


### PR DESCRIPTION
## Summary

- Replace the two deprecated `Tuple{Vararg{<:T}}` annotations with `Tuple{Vararg{T}}`.
- Preserve existing tuple dispatch while removing the Julia precompilation warnings.

## Validation

- Uncached package load on Julia 1.12.6 with `--depwarn=error`.
- `git diff --check upstream/master...HEAD`

The test suite was not run, as requested for this signature-only change.