### PR TITLE
Run downgrade CI on minimum supported Julia

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -37,9 +37,12 @@ jobs:
           mode: 'forcedeps'
           julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Instantiate the locked test environment
-        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
-      - name: Run tests without re-resolving
-        env:
-          JULIA_LOAD_PATH: ${{ github.workspace }}/test:${{ github.workspace }}:@stdlib
-        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl
+      - name: Run tests
+        run: |
+          julia --project=test --color=yes -e '
+            import Pkg
+            Pkg.develop(Pkg.PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            Pkg.status(; mode=Pkg.PKGMODE_MANIFEST)
+            include("test/runtests.jl")
+          '

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'min'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -35,8 +35,11 @@ jobs:
           projects: '.,test'
           skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
+          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-          force_latest_compatible_version: false
+      - name: Instantiate the locked test environment
+        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
+      - name: Run tests without re-resolving
+        env:
+          JULIA_LOAD_PATH: ${{ github.workspace }}/test:${{ github.workspace }}:@stdlib
+        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl


### PR DESCRIPTION
## Summary

- run downgrade resolution on the minimum Julia version declared by the package
- test the dependency floors without dependency-specific manifest mutations
- use the documented pre-1.12 `julia-downgrade-compat` test harness

## Root cause

The Julia 1.12 downgrade job combined the direct PrecompileTools 1.2.1 floor with the latest transitive RuntimeGeneratedFunctions 0.5.25. The latter added a workload that is incompatible with PrecompileTools 1.2.1 specifically on Julia 1.12. Julia Project compatibility cannot express a Julia-version-conditional dependency floor.

The downgrade job now tests the lower-bound corner on the package minimum Julia version. Following the action documentation for Julia versions before 1.12, it develops the checkout into the locked test environment, instantiates that environment, reports the manifest, and includes the test entry point directly. Ordinary CI continues to test Julia 1.10 and current Julia with normally resolved dependencies.

## Validation

- [x] parsed the revised workflow and passed `git diff --check`
- [x] resolved Julia `min` to Julia 1.10 with `julia-downgrade-compat` v2.7.0
- [x] verified every forced direct dependency floor
- [x] built the downgraded root environment
- [x] ran the documented pre-1.12 harness on Julia 1.10.12
- [x] ran the full locked suite: 2,258 passed, one expected broken test

No changelog entry is needed because this changes CI only.