### PR TITLE
Use DocumenterCodeBlocks in the docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 AnythingLLMDocs = "333fe5f5-19c9-4863-8caf-c9193e7dba62"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
 QuantumInterface = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 QuantumOpticsBase = "4f57444f-1401-5e15-980d-4471b28d5678"
 
 [compat]
 Documenter = "1"
+DocumenterCodeBlocks = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter
+using DocumenterCodeBlocks
 using AnythingLLMDocs
 using QuantumInterface
 using QuantumOpticsBase
@@ -24,6 +25,7 @@ makedocs(
     sitename = "QuantumOpticsBase.jl",
     modules = doc_modules,
     pages = pages,
+    plugins = [CodeBlocks()],
     format = Documenter.HTML(assets = anythingllm_assets),
     checkdocs=:exports
     )


### PR DESCRIPTION
## Summary

- add DocumenterCodeBlocks to the documentation environment with a major-version compatibility bound
- enable `CodeBlocks()` in the standard `makedocs` call, so its built-in docstring-quality diagnostics run during every documentation build
- rebase the unchanged integration patch onto `master` after #267

## Local validation

- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=conservative julia --project=docs/ --startup-file=no -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.status()'`
- `julia --project=docs/ --startup-file=no --color=no docs/make.jl`

The documentation build completed successfully with Julia 1.12.6, Documenter 1.19.0, and DocumenterCodeBlocks 1.5.0. The build log includes `DocumenterCodeBlocks: processing code blocks` and no `CodeBlocks:` diagnostic owned by QuantumOpticsBase. Five diagnostics remain for QuantumInterface-owned docstrings and are outside this repository.
