### PR TITLE
Require a state argument for tensor products

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -106,12 +106,14 @@ tensor(a::Ket, b::Ket) = Ket(tensor(a.basis, b.basis), kron(b.data, a.data))
 tensor(a::Bra, b::Bra) = Bra(tensor(a.basis, b.basis), kron(b.data, a.data))
 tensor(state::Ket) = state
 tensor(state::Bra) = state
-function tensor(states::Ket...)
+function tensor(state::Ket, states::Ket...)
+    states = (state, states...)
     bases = map(state -> state.basis, states)
     data = map(state -> state.data, states)
     Ket(tensor(bases...), foldr(kron, reverse(data)))
 end
-function tensor(states::Bra...)
+function tensor(state::Bra, states::Bra...)
+    states = (state, states...)
     bases = map(state -> state.basis, states)
     data = map(state -> state.data, states)
     Bra(tensor(bases...), foldr(kron, reverse(data)))

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,6 +1,7 @@
 @testitem "test_states" begin
 using Test
 using QuantumOpticsBase
+using QuantumInterface
 using LinearAlgebra, Random
 using SparseArrays
 
@@ -72,6 +73,7 @@ ket_b3 = randstate(b3)
 @test 1e-14 > D((bra_b1 ⊗ bra_b2)*(ket_b1 ⊗ ket_b2), (bra_b1*ket_b1)*(bra_b2*ket_b2))
 
 # Tensor product
+pkgversion(QuantumInterface) >= v"0.4.4" && @test !applicable(tensor)
 @test tensor(ket_b1) === ket_b1
 @test tensor(bra_b1) === bra_b1
 @test 1e-14 > D((ket_b1 ⊗ ket_b2) ⊗ ket_b3, ket_b1 ⊗ (ket_b2 ⊗ ket_b3))


### PR DESCRIPTION
## Summary
- require at least one `Ket` or `Bra` in variadic state tensor methods
- preserve unary, binary, and N-ary tensor products
- add regression coverage that `tensor()` is unsupported

## Tests
- focused zero/unary/binary/N-ary `Ket` and `Bra` checks
- repository-configured Aqua checks