### PR TITLE
Improve audited API docstrings

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -357,6 +357,7 @@ NLevelBasis
 
 ```@docs
 transition(::Type{T}, ::NLevelBasis, ::Integer, ::Integer) where T
+transition(::NLevelBasis, ::Integer, ::Integer)
 ```
 
 ```@docs
@@ -509,6 +510,7 @@ create(::Type{T}, ::ManyBodyBasis, index) where T
 
 ```@docs
 transition(::Type{T}, ::ManyBodyBasis, i, j) where T
+transition(::ManyBodyBasis, i, j)
 ```
 
 ```@docs

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -143,6 +143,11 @@ function displace_analytical(::Type{T}, b::FockBasis, alpha::Number) where T
     displace_analytical!(DenseOperator(T, b), alpha)
 end
 
+"""
+    displace_analytical(b::FockBasis, alpha::Number)
+
+Create the analytical displacement operator with `ComplexF64` elements.
+"""
 displace_analytical(b::FockBasis, alpha::Number) = displace_analytical(ComplexF64, b::FockBasis, alpha::Number)
 
 

--- a/src/manybody.jl
+++ b/src/manybody.jl
@@ -166,6 +166,11 @@ function transition(::Type{T}, mb::ManyBodyBasis, to, from) where {T}
     end
     return SparseOperator(mb, sparse(Is, Js, Vs, length(mb), length(mb)))
 end
+"""
+    transition(mb::ManyBodyBasis, to, from)
+
+Create a transition operator with `ComplexF64` elements.
+"""
 transition(mb::ManyBodyBasis, to, from) = transition(ComplexF64, mb, to, from)
 
 # Calculate many-Body operator from one-body operator

--- a/src/nlevel.jl
+++ b/src/nlevel.jl
@@ -16,6 +16,11 @@ function transition(::Type{T}, b::NLevelBasis, to::Integer, from::Integer) where
     op.data[to, from] = 1.
     op
 end
+"""
+    transition(b::NLevelBasis, to::Integer, from::Integer)
+
+Create a transition operator with `ComplexF64` elements.
+"""
 transition(b::NLevelBasis,to::Integer,from::Integer) = transition(ComplexF64,b,to,from)
 
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -4,6 +4,8 @@ import SparseArrays: sparse
 import QuantumInterface: AbstractOperator, AbstractKet
 
 """
+    DataOperator{BL,BR} <: AbstractOperator{BL,BR}
+
 Abstract type for operators with a data field.
 
 This is an abstract type for operators that have a direct matrix representation

--- a/src/operators_lazytensor.jl
+++ b/src/operators_lazytensor.jl
@@ -261,7 +261,10 @@ end
 
 """
     lazytensor_enable_cache(; maxsize::Int = ..., maxrelsize::Real = ...)
-(Re)-enable the cache for further use; set the maximal size `maxsize` (as number of bytes)
+
+Enable the lazy-tensor cache.
+
+Set the maximal size `maxsize` (as number of bytes)
 or relative size `maxrelsize`, as a fraction between 0 and 1, resulting in
 `maxsize = floor(Int, maxrelsize * Sys.total_memory())`. Default value is `maxsize = 2^32` bytes, which amounts to 4 gigabytes of memory.
 """

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -144,6 +144,11 @@ function potentialoperator(::Type{T}, b::PositionBasis, V) where T
     x = convert.(T, samplepoints(b))
     diagonaloperator(b, V.(x))
 end
+"""
+    potentialoperator(b::PositionBasis, V)
+
+Create a real-space potential operator with `Float64` elements.
+"""
 potentialoperator(b::PositionBasis, V) = potentialoperator(Float64, b, V)
 
 """
@@ -155,6 +160,11 @@ function potentialoperator(::Type{T}, b::MomentumBasis, V) where T
     b_pos = PositionBasis(b)
     transform(b, b_pos)*dense(potentialoperator(T, b_pos, V))*transform(b_pos, b)
 end
+"""
+    potentialoperator(b::Basis, V)
+
+Create a potential operator with `ComplexF64` elements.
+"""
 potentialoperator(b::Basis, V) = potentialoperator(ComplexF64, b, V)
 
 """

--- a/src/states.jl
+++ b/src/states.jl
@@ -97,15 +97,15 @@ Hermitian conjugate.
 dagger(x::Bra) = Ket(x.basis, conj(x.data))
 dagger(x::Ket) = Bra(x.basis, conj(x.data))
 
-"""
-    tensor(x::Ket, y::Ket, z::Ket...)
-
-Tensor product ``|x⟩⊗|y⟩⊗|z⟩⊗…`` of the given states.
-"""
 tensor(a::Ket, b::Ket) = Ket(tensor(a.basis, b.basis), kron(b.data, a.data))
 tensor(a::Bra, b::Bra) = Bra(tensor(a.basis, b.basis), kron(b.data, a.data))
 tensor(state::Ket) = state
 tensor(state::Bra) = state
+"""
+    tensor(state::Ket, states::Ket...)
+
+Tensor product ``|x⟩⊗|y⟩⊗|z⟩⊗…`` of the given states.
+"""
 function tensor(state::Ket, states::Ket...)
     states = (state, states...)
     bases = map(state -> state.basis, states)
@@ -169,6 +169,11 @@ function basisstate(::Type{T}, b::Basis, index::Integer) where T
     data[index] = one(T)
     Ket(b, data)
 end
+"""
+    basisstate(b::Basis, indices)
+
+Create a basis state with `ComplexF64` coefficients.
+"""
 basisstate(b::Basis, indices) = basisstate(ComplexF64, b, indices)
 
 """


### PR DESCRIPTION
## Summary

- add independent signatures and short descriptions for audited convenience methods
- attach the ket tensor documentation to the variadic method and include both transition wrappers in the API manual
- add the missing `DataOperator` signature and shorten the lazy-tensor cache summary

This branch is based directly on `master`, keeps package dependency metadata unchanged, and does not include the DocumenterCodeBlocks builder integration. I tested DocStringExtensions placeholders, but QuantumOpticsBase does not currently depend on that package and adding it solely for these docstrings makes the required cold-start comparison reject the changed dependency metadata. The final dependency-neutral signatures are therefore explicit.

## Validation

- DocumenterCodeBlocks 1.5.0 audit build with targeted typed and convenience calls: no QuantumOpticsBase warnings (the five QuantumInterface-owned audit warnings remain)
- focused Julia `Docs` metadata assertions for every audited convenience signature
- `Pkg.test()` on Julia 1.12.6: 2271 passed, 2 broken
- `git diff --check`