### PR TITLE
Fix Julia 1.13 tests and cover every supported Julia minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1.10'
-          - os: ubuntu-latest
-            arch: x64
-            version: '1.11'
-          - os: ubuntu-latest
-            arch: x64
-            version: '1.12'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1.10'
+          - os: ubuntu-latest
+            arch: x64
+            version: '1.11'
+          - os: ubuntu-latest
+            arch: x64
+            version: '1.12'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -142,8 +142,9 @@ Lop1 = LazyTensor(b1^2, b2^2, 2, sparse(randoperator(b1, b2)))
 @test all(size(Lop1, k) == size(dense(Lop1), k) for k=1:4)
 @test_throws ErrorException size(Lop1,  0)
 @test_throws ErrorException size(Lop1, -1)
-@test_throws ErrorException size(dense(Lop1),  0) # check for consistency
-@test_throws ErrorException size(dense(Lop1), -1)
+# Julia 1.13 changed invalid Array dimensions from ErrorException to BoundsError.
+@test_throws Union{ErrorException,BoundsError} size(dense(Lop1),  0)
+@test_throws Union{ErrorException,BoundsError} size(dense(Lop1), -1)
 
 # issue 106 | https://github.com/qojulia/QuantumOpticsBase.jl/issues/106
 a = destroy(FockBasis(5))


### PR DESCRIPTION
Julia 1.13 changes `size(::Array, d)` for nonpositive dimensions from `ErrorException` to `BoundsError`. The dense operator delegates to its array, so two assertions fail on all three operating systems in [master CI](https://github.com/qojulia/QuantumOpticsBase.jl/actions/runs/34535670567). Accept the two supported exception types.

Add Ubuntu jobs for Julia 1.11 and 1.12. Together with the existing Julia 1.10 job and latest-release jobs (currently Julia 1.13), CI covers every supported Julia minor.

Validation:

- Reproduced the Base exception change on Julia 1.12.7 and 1.13.0. All 58 focused operator assertions pass locally on Julia 1.13.0.
- Full local `Pkg.test()` on Julia 1.13.0 passes with this PR: 2,353 passed and two existing broken tests. Unchanged master failed only the two corrected assertions (2,351 passed, two failed, two broken). Master also passes the full normal suite locally on Julia 1.10.12, 1.11.9, and 1.12.7.
- All six [CI matrix jobs](https://github.com/qojulia/QuantumOpticsBase.jl/actions/runs/34549081413) pass: Julia 1.10, 1.11, and 1.12 on Ubuntu, plus Julia 1.13 on Ubuntu, Windows, and macOS. Documentation and coverage pass.
- With this PR and the separately reviewed fixes in [#270](https://github.com/qojulia/QuantumOpticsBase.jl/pull/270) and [#271](https://github.com/qojulia/QuantumOpticsBase.jl/pull/271) combined, full local `Pkg.test()` passes on all supported minors: 2,355 passed/two existing broken on Julia 1.10.12, 1.12.7, and 1.13.0; 2,354 passed/three existing broken on Julia 1.11.9. These runs include Aqua, doctests, and plotting.
- Separate local JET and CPU OpenCL suites pass on all four minors with #271. OpenCL passes 241 assertions per version, including device availability. JET passes 85 checks with 70 expected broken on Julia 1.10 and 86 checks with 69 expected broken on Julia 1.11–1.13. CUDA/AMDGPU cannot run on the exposed local hardware.
- Julia 1.13 documentation builds pass both with this PR alone and with all three fixes combined. Focused operators/states/lazytensor checks pass 350/350 on Julia 1.10 and 1.11 with all three fixes.
- Workflow matrix validation, `git diff --check`, and independent review pass.

The separate downgrade failure is fixed by #270, whose downgrade CI and full local minimum-dependency suite pass with Makie 0.24.11.
